### PR TITLE
OSD-6239: initial runbooks

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,47 @@
+# See https://github.com/DavidAnson/markdownlint#optionsconfig
+# and https://github.com/DavidAnson/markdownlint-cli2
+
+config:
+  # forematter metadata seems to trigger this
+  single-title: false
+
+  # hard tabs are used when pasting go example code into files
+  no-hard-tabs: false
+
+  # we commonly paste bare urls in the middle of paragraphs
+  no-bare-urls: false
+
+  # really, this is a rule?
+  commands-show-output: false
+
+  # We like to use really long lines
+  line-length:
+    line_length: 80
+    code_blocks: false
+
+  # Sometimes we repeat headings, and it's easier to just turn those
+  # into emphasis
+  no-emphasis-as-heading: false
+
+  # We only publish HTML, so allow all HTML inline.
+  no-inline-html: false
+
+  ## Rules we may want to turn on later, but that will require editing
+  ## existing files:
+
+  # We tend to use `*` instead of `-` for list bullets but we aren't
+  # consistent, even within a single file. Ideally we would want
+  # `style: consistent`
+  ul-style: false
+
+  # We have at least one # document that breaks up a numbered list
+  # with headings.  Ideally we would set `style: one_or_ordered`.
+  ol-prefix: false
+
+  # Vertical whitespace helps the reader, so we should turn these on
+  # again when someone has time to fix our existing files.
+  blanks-around-fences: false
+  blanks-around-headings: false
+  blanks-around-lists: false
+  single-trailing-newline: false
+  no-multiple-blanks: false

--- a/alerts/AggregatedAPIErrors.md
+++ b/alerts/AggregatedAPIErrors.md
@@ -44,19 +44,18 @@ $ oc get apiservice
 The `SERVICE` column notes here the aggregated API name. The availability status
 for every listed API should be `True`. A `False` means that requests for that
 API service, API server pods, or resources belonging to that apiGroup failed
-many times during the last minutes. For the case that the logs of the particular
-pods should be investigated.
+many times during the last minutes.
 
-To get the pods that serve the `openshift-apiserver/api` can be fetched with the
-following command:  
+Fetch the pods that serve the unavailable API. E.g.: for
+`openshift-apiserver/api` use the following command:  
 
 ```console
 $ oc get pods -n openshift-apiserver
 ```
 
-If their status is not `Running`, check the logs for more details. As these pods
-are controlled by a deployment, they can be restart in case they are not
-answering requests anymore.
+When their status is not `Running`, check the logs for more details. As these
+pods are controlled by a deployment, they can be restart when they are not
+answering to requests anymore.
 
 ### Check the authentication certificates of the aggregated API
 
@@ -66,7 +65,7 @@ Make sure the certificates are up to date and still valid. Use:
 $ oc get configmaps -n kube-system extension-apiserver-authentication
 ```
 
-you can save those certificates into a file and use the following command to
+You can save those certificates into a file and use the following command to
 check the end dates:
 
 ```console

--- a/alerts/AggregatedAPIErrors.md
+++ b/alerts/AggregatedAPIErrors.md
@@ -1,0 +1,80 @@
+# AggregatedAPIErrors
+
+## Meaning
+
+[This alert][AggregatedAPIErrors] is triggered when multiple calls to the
+aggregated API of OpenShift fail over a certain period.
+
+## Impact
+
+Errors on the aggregated API can result in the unavailability of some OpenShift
+services.  
+
+## Diagnosis
+
+The alert should contain information about the affected API and the scope of the
+impact.
+
+```text
+ - alertname = AggregatedAPIErrors
+ - name = v1.packages.operators.coreos.com
+ - namespace = default
+...
+ - message = An aggregated API v1.packages.operators.coreos.com/default has reported errors. The number of errors have increased for it in the past five minutes. High values indicate that the availability of the service changes too often.
+```
+
+## Mitigation
+
+### Check the APIs status checks are on True
+
+Currently, there are at least four aggregated APIs in an OpenShift Cluster. The
+API on the `openshift-apiserver` namespace, the prometheus-adapter on the
+namespace `openshift-monitoring`, the package-server service in the
+`openshift-operator-lifecycle-manager` namespace, and the API on the
+`openshift-oauth-apiserver` namespace. However, it makes sense to check the
+availability of all APIs.
+
+To get a list of `APIServices` and their backing aggregated APIs, use the
+following command:
+
+```console
+$ oc get apiservice 
+```
+
+The `SERVICE` column notes here the aggregated API name. The availability status
+for every listed API should be `True`. A `False` means that requests for that
+API service, API server pods, or resources belonging to that apiGroup failed
+many times during the last minutes. For the case that the logs of the particular
+pods should be investigated.
+
+To get the pods that serve the `openshift-apiserver/api` can be fetched with the
+following command:  
+
+```console
+$ oc get pods -n openshift-apiserver
+```
+
+If their status is not `Running`, check the logs for more details. As these pods
+are controlled by a deployment, they can be restart in case they are not
+answering requests anymore.
+
+### Check the authentication certificates of the aggregated API
+
+Make sure the certificates are up to date and still valid. Use:
+
+```console
+$ oc get configmaps -n kube-system extension-apiserver-authentication
+```
+
+you can save those certificates into a file and use the following command to
+check the end dates:
+
+```console
+$ openssl x509 -noout -enddate -in {myfile_with_certs.crt}
+```
+
+Those certificates are used by the aggregated APIs to validate requests. For the
+case, they are expired check [here][cert] how to add a new one.
+
+[cert]: https://docs.openshift.com/container-platform/latest/security/certificates/api-server.html
+[AggregatedAPIErrors]: https://github.com/openshift/cluster-monitoring-operator/blob/aefc8fc5fc61c943dc1ca24b8c151940ae5f8f1c/assets/control-plane/prometheus-rule.yaml#L440-L449

--- a/alerts/ClusterOperatorDegraded.md
+++ b/alerts/ClusterOperatorDegraded.md
@@ -4,21 +4,21 @@
 
 The alert `ClusterOperatorDegraded` is fired by
 [cluster-version-operator](https://github.com/openshift/cluster-version-operator)(CVO)
-when a `ClusterOperator` is in `degraded` state for certain period of time. An
+when a `ClusterOperator` is in `degraded` state for a certain period. An
 operator reports `Degraded` when its current state does not match its desired
-state over a period resulting in a lower quality of service.The time may vary by
-component, but a `Degraded` state represents the persistent observation of a
-condition. A service may be `Available` even if it is degraded. For example,
-your service may desire 3 running pods, but 1 pod is in a crash-looping. The
-service is `Available` but `Degraded` because it may have a lower quality of
+state over a period resulting in a lower quality of service. The time may vary
+by component, but a `Degraded` state represents the persistent observation of a
+condition. A service state may be `Available` even when degraded. For example,
+your service may desire three running pods, but one pod is in a crash-looping.
+The service is `Available` but `Degraded` because it may have a lower quality of
 service. A component may be `Progressing` but not `Degraded` because the
 transition from one state to another does not persist over a long enough period
 to report `Degraded`. A service should not report `Degraded` during a normal
 upgrade. A service may report `Degraded` in response to a persistent
-infrastructure failure that requires administrator intervention. For example, if
-a control plane host is unhealthy and must be replaced. An operator should
-report `Degraded` if unexpected errors occur over a period, but the expectation
-is that all unexpected errors are handled as operators mature.
+infrastructure failure that requires administrator intervention. For example,
+when a control plane host is unhealthy and has to be replaced. An operator
+should report `Degraded` if unexpected errors occur over a period, but the
+expectation is that all unexpected errors are handled as operators mature.
 
 ## Impact
 

--- a/alerts/ClusterOperatorDegraded.md
+++ b/alerts/ClusterOperatorDegraded.md
@@ -1,0 +1,76 @@
+# ClusterOperatorDegraded
+
+## Meaning
+
+The alert `ClusterOperatorDegraded` is fired by
+[cluster-version-operator](https://github.com/openshift/cluster-version-operator)(CVO)
+when a `ClusterOperator` is in `degraded` state for certain period of time. An
+operator reports `Degraded` when its current state does not match its desired
+state over a period resulting in a lower quality of service.The time may vary by
+component, but a `Degraded` state represents the persistent observation of a
+condition. A service may be `Available` even if it is degraded. For example,
+your service may desire 3 running pods, but 1 pod is in a crash-looping. The
+service is `Available` but `Degraded` because it may have a lower quality of
+service. A component may be `Progressing` but not `Degraded` because the
+transition from one state to another does not persist over a long enough period
+to report `Degraded`. A service should not report `Degraded` during a normal
+upgrade. A service may report `Degraded` in response to a persistent
+infrastructure failure that requires administrator intervention. For example, if
+a control plane host is unhealthy and must be replaced. An operator should
+report `Degraded` if unexpected errors occur over a period, but the expectation
+is that all unexpected errors are handled as operators mature.
+
+## Impact
+
+An operator has encountered an error that is preventing it or its operand from
+working properly. The operand may still be available, but its intent may not be
+fulfilled. If this is true, it means that the operand is at risk of an outage or
+improper configuration.
+
+## Diagnosis
+
+The alert would convey exactly which operator the alert was fired for. The
+operator name will be displayed under the `name` label. For example:
+
+```text
+ - alertname = ClusterOperatorDegraded
+...
+ - name = console
+...
+```
+
+First, log in to the cluster. Multiple operators could be degraded at the same
+time. Check the status of all operators to know whether there are more
+`Degraded`:
+
+```console
+$ oc get clusteroperator
+```
+
+Typically, the status will give some hint about the operator state.
+
+```console
+$ oc get clusteroperator $CLUSTEROPERATOR -ojson | jq .status.conditions
+```
+
+Further on, if you would like to go through the associated resources for that
+particular operator, you can use the command:
+
+```console
+$ oc get clusteroperator $CLUSTEROPERATOR -ojson | jq .status.relatedObjects
+```
+
+Collect logs and artifacts for a given operator. As an example, you can collect
+the logs of a specific operator and store them in a local directory named `out`
+by using the following command:
+
+```console
+$ oc adm inspect clusteroperator/$CLUSTEROPERATOR --dest-dir=out
+```
+
+## Mitigation
+
+The resolution steps would vary and depend on the particular `ClusterOperator`
+that is in consideration. If there is an upgrade going on, then the `Degraded`
+state may recover itself in some time. If a `ClusterOperator` is misconfigured,
+then try to find the error in the collected logs and fix the configuration.

--- a/alerts/ClusterOperatorDown.md
+++ b/alerts/ClusterOperatorDown.md
@@ -4,7 +4,7 @@
 
 The alert `ClusterOperatorDown` is fired by
 [cluster-version-operator](https://github.com/openshift/cluster-version-operator)
-(CVO) when a `ClusterOperator` is not in the `Available` state for certain
+(CVO) when a `ClusterOperator` is not in the `Available` state for a certain
 period. An operand that is functional in the cluster is `Available`.
 
 ## Impact

--- a/alerts/ClusterOperatorDown.md
+++ b/alerts/ClusterOperatorDown.md
@@ -1,0 +1,59 @@
+# ClusterOperatorDown
+
+## Meaning
+
+The alert `ClusterOperatorDown` is fired by
+[cluster-version-operator](https://github.com/openshift/cluster-version-operator)
+(CVO) when a `ClusterOperator` is not in the `Available` state for certain
+period. An operand that is functional in the cluster is `Available`.
+
+## Impact
+
+There is an outage that needs to be checked at the earliest.
+
+## Diagnosis
+
+The alert would convey exactly which operator the alert is for. The message will
+contain the name. For example:
+
+```text
+ - alertname = ClusterOperatorDown
+...
+ - name = console
+...
+```
+
+First, log in to the cluster. Multiple operators could be down at the same time.
+Check the status of all operators to know whether more are not `Available`:
+
+```console
+$ oc get clusteroperator
+```
+
+Typically, the status will give some hint about its state. Investigate further
+for the operator that is not `Available` by using the following command:
+
+```console
+$ oc get clusteroperator $CLUSTEROPERATOR -ojson | jq .status.conditions
+```
+
+Further on, if you would like to go through the associated resources for that
+particular operator, you can use the command:
+
+```console
+$ oc get clusteroperator $CLUSTEROPERATOR -ojson | jq .status.relatedObjects
+```
+
+Collect logs and artifacts for a given operator. As an example, you can collect
+the logs of a specific operator and store them in a local directory named `out`
+by using the following command:
+
+```console
+$ oc adm inspect clusteroperator/$CLUSTEROPERATOR --dest-dir=out
+```
+
+## Mitigation
+
+The resolution steps would vary and depend on the particular operator that is in
+consideration. If there is an upgrade going on, then this issue may resolve
+itself after some time. Otherwise, try to find an error in the logs.

--- a/alerts/KubeDeploymentReplicasMismatch.md
+++ b/alerts/KubeDeploymentReplicasMismatch.md
@@ -1,0 +1,53 @@
+# KubeDeploymentReplicasMismatch
+
+## Meaning
+
+This alert is fired in case of a discrepancy between the desired number of replicas
+to the actual number of running instances was observed for deployment over a
+certain period.
+
+## Impact
+
+This strength of the impact very much differs depending on the discrepancy.
+
+## Diagnosis
+
+The alert should note where the discrepancy occurred under the `deployment`
+label.
+
+### elasticsearch-*
+
+The notification details should list the deployment with the mismatch (and the
+deployment's namespace). For example:
+
+```console
+ - alertname = KubeDeploymentReplicasMismatch
+...
+ - deployment = elasticsearch-cdm-u1gqqbu6-2
+...
+ - namespace = openshift-logging
+...
+```
+
+Start by checking the status of the deployment:
+
+```console
+$ oc get deploy -n $NAMESPACE $DEPLOYMENT
+```
+
+Possibilities include (but are not limited to) a pod stuck in
+`ContainerCreating` or `CrashLoopBackoff`.
+
+### etcd-quorum-guard-*"
+
+Review the current deployment using the details available in the alert.
+Review the following in the target namespace to ascertain the reason behind this:
+* events
+* pods
+* nodes (check scheduling status)
+
+## Mitigation
+
+The specific instance that was resolved using the above required deleting all 3
+of the `etcd-quorum-guard` pods.
+

--- a/alerts/KubeDeploymentReplicasMismatch.md
+++ b/alerts/KubeDeploymentReplicasMismatch.md
@@ -2,23 +2,18 @@
 
 ## Meaning
 
-This alert is fired in case of a discrepancy between the desired number of replicas
-to the actual number of running instances was observed for deployment over a
-certain period.
+This alert is fired when a discrepancy between the desired number of replicas to
+the actual number of running instances for deployment was observed for a certain
+period.
 
 ## Impact
 
-This strength of the impact very much differs depending on the discrepancy.
+The impact very much differs depending on the discrepancy.
 
 ## Diagnosis
 
 The alert should note where the discrepancy occurred under the `deployment`
-label.
-
-### elasticsearch-*
-
-The notification details should list the deployment with the mismatch (and the
-deployment's namespace). For example:
+label:
 
 ```console
  - alertname = KubeDeploymentReplicasMismatch
@@ -35,19 +30,45 @@ Start by checking the status of the deployment:
 $ oc get deploy -n $NAMESPACE $DEPLOYMENT
 ```
 
+Review the current deployment using the details available in the alert. Review
+the following in the target namespace to ascertain the reason behind this. The
+events:
+
+```console
+$ oc get events -n $NAMESPACE
+```
+
+Further, check the states of the Pods that the deployment manages:
+
+```console
+$ oc get pods -n $NAMESPACE --selector=app=$DEPLOYMENT
+```
+
 Possibilities include (but are not limited to) a pod stuck in
-`ContainerCreating` or `CrashLoopBackoff`.
+`ContainerCreating` or `CrashLoopBackoff`. The events may list this case
+information about possible failed actions of a pod. Application and startup
+failures should be visible with:
 
-### etcd-quorum-guard-*"
+```console
+$ oc describe pod $POD
+```
 
-Review the current deployment using the details available in the alert.
-Review the following in the target namespace to ascertain the reason behind this:
-* events
-* pods
-* nodes (check scheduling status)
+If Pods are stuck in `Pending`, it means that insufficient resources prevent the
+pod from being scheduled. Check the health of the nodes.
+
+```console
+$ oc get nodes
+```
+
+It is further possible that the CPU and Memory of the host are exhausted.
+
+```console
+$ oc adm top nodes
+```
 
 ## Mitigation
 
-The specific instance that was resolved using the above required deleting all 3
-of the `etcd-quorum-guard` pods.
-
+Resolve the problems discovered during the diagnosis according to the
+documentation. It is safe to delete the pods since they are managed by the
+deployment. However, it may also be required to add more nodes in case of
+insufficient resources.

--- a/alerts/KubeJobFailed.md
+++ b/alerts/KubeJobFailed.md
@@ -2,13 +2,13 @@
 
 ## Meaning
 
-[This alert][KubeJobFailed] is triggered for the case that the number of job execution
-attempts exceeds the `backoffLimit`. A job can therefore create one or many pods
-for its tasks.
+[This alert][KubeJobFailed] is triggered for the case that the number of job
+execution attempts exceeds the `backoffLimit`. A job can therefore create one or
+many pods for its tasks.
 
 ## Impact
 
-A task has not finished correctly. Depending on the task, this has an different
+A task has not finished correctly. Depending on the task, this has a different
 impact.
 
 ## Diagnosis
@@ -18,38 +18,31 @@ Follow the particular mitigation steps according to that. For example:
 
 ```text
  - alertname = KubeJobFailed
+...
+ - job_name = elasticsearch-delete-app-1600903800
+ - namespace = openshift-logging
 ... 
  - message = Job openshift-logging/elasticsearch-delete-app-1600855200 failed to complete.
 ```
 
 ## Mitigation
 
-### Failed `elasticsearch-*` jobs in `openshift-logging` namespace
-
-Make sure you are in the `openshift-logging` project
+Find the pods that belong to that job:
 
 ```console
-$ oc project openshift-logging
+$ oc get pod -n $NAMESPACE -l job-name=$JOBNAME
 ```
 
-Look at the elasticsearch pods. One easy way to filter these is to use the
-`component` label with the value `indexManagement`:
-
-```console
-$ oc get pod -l component=indexManagement
-```
-
-If, as in this case, you see an `Error` pod with a subsequent `Completed` pod of
-the same base name, the error was transient, and the `Error` pod can be deleted
-safely.
+If you see an `Error` pod with a subsequent `Completed` pod of
+the same base name, the error was transient, and the `Error` pod can safely be deleted.
 
 Have a look at the jobs themselves:
 
 ```console
-$ oc get jobs -n openshift-logging
+$ oc get jobs -n $NAMESPACE
 ```
 
-If, as in this case, there is a healthy job for every failed one, it is safe to
-delete the failed jobs. The alert should resolve itself after a few minutes.
+If there is a healthy job for every failed one, it is safe to delete the failed
+jobs. The alert should resolve itself after a few minutes.
 
 [KubeJobFailed]: https://github.com/openshift/cluster-monitoring-operator/blob/aefc8fc5fc61c943dc1ca24b8c151940ae5f8f1c/assets/control-plane/prometheus-rule.yaml#L186-L195

--- a/alerts/KubeJobFailed.md
+++ b/alerts/KubeJobFailed.md
@@ -1,0 +1,55 @@
+# KubeJobFailed
+
+## Meaning
+
+[This alert][KubeJobFailed] is triggered for the case that the number of job execution
+attempts exceeds the `backoffLimit`. A job can therefore create one or many pods
+for its tasks.
+
+## Impact
+
+A task has not finished correctly. Depending on the task, this has an different
+impact.
+
+## Diagnosis
+
+The alert should contain the job name and the namespace where that job failed.
+Follow the particular mitigation steps according to that. For example:
+
+```text
+ - alertname = KubeJobFailed
+... 
+ - message = Job openshift-logging/elasticsearch-delete-app-1600855200 failed to complete.
+```
+
+## Mitigation
+
+### Failed `elasticsearch-*` jobs in `openshift-logging` namespace
+
+Make sure you are in the `openshift-logging` project
+
+```console
+$ oc project openshift-logging
+```
+
+Look at the elasticsearch pods. One easy way to filter these is to use the
+`component` label with the value `indexManagement`:
+
+```console
+$ oc get pod -l component=indexManagement
+```
+
+If, as in this case, you see an `Error` pod with a subsequent `Completed` pod of
+the same base name, the error was transient, and the `Error` pod can be deleted
+safely.
+
+Have a look at the jobs themselves:
+
+```console
+$ oc get jobs -n openshift-logging
+```
+
+If, as in this case, there is a healthy job for every failed one, it is safe to
+delete the failed jobs. The alert should resolve itself after a few minutes.
+
+[KubeJobFailed]: https://github.com/openshift/cluster-monitoring-operator/blob/aefc8fc5fc61c943dc1ca24b8c151940ae5f8f1c/assets/control-plane/prometheus-rule.yaml#L186-L195

--- a/alerts/KubeNodeNotReady.md
+++ b/alerts/KubeNodeNotReady.md
@@ -1,0 +1,54 @@
+# KubeNodeNotReady
+
+## Meaning
+
+[This alert][KubeNodeNotReady] is fired when a Kubernetes node is not in `Ready`
+state for a certain period. In this case, the node is not able to host any new
+pods as described [here][KubeNode].
+
+## Impact
+
+The performance of the cluster deployments is affected, depending on the overall
+workload and the type of the node.
+
+## Diagnosis
+
+The notification details should list the node that's not ready. For Example:
+
+```txt
+ - alertname = KubeNodeNotReady
+...
+ - node = node1.example.com
+...
+```
+
+Login to the cluster. Check the status of that node:
+
+```console
+$ oc get node $NODE -o yaml
+```
+
+The output should describe why the node isn't ready (e.g.: timeouts reaching the
+API or kubelet)
+Check the machine for the node:
+
+```console
+$ oc get -n openshift-machine-api machine $NODE -o yaml
+```
+
+and the events for the machine API:
+
+```console
+$ oc get -n openshift-machine-api events
+```
+
+If the machine API is not able to replace the node, the machine status and
+events should detail why.
+
+## Mitigation
+
+Once the problem was resolved that prevented the machine API from replacing the
+node, the instance should be terminated and replaced by the machine API.
+
+[KubeNode]: https://kubernetes.io/docs/concepts/architecture/nodes/#condition
+[KubeNodeNotReady]: https://github.com/openshift/cluster-monitoring-operator/blob/aefc8fc5fc61c943dc1ca24b8c151940ae5f8f1c/assets/control-plane/prometheus-rule.yaml#L482-L490

--- a/alerts/KubeNodeNotReady.md
+++ b/alerts/KubeNodeNotReady.md
@@ -29,8 +29,7 @@ $ oc get node $NODE -o yaml
 ```
 
 The output should describe why the node isn't ready (e.g.: timeouts reaching the
-API or kubelet)
-Check the machine for the node:
+API or kubelet) Check the machine for the node:
 
 ```console
 $ oc get -n openshift-machine-api machine $NODE -o yaml
@@ -47,8 +46,10 @@ events should detail why.
 
 ## Mitigation
 
-Once the problem was resolved that prevented the machine API from replacing the
+Once, the problem was resolved that prevented the machine API from replacing the
 node, the instance should be terminated and replaced by the machine API.
+However, this is only the case `MachineHealthChecks` are enabled for the nodes
+otherwise a manual restart is required.
 
 [KubeNode]: https://kubernetes.io/docs/concepts/architecture/nodes/#condition
 [KubeNodeNotReady]: https://github.com/openshift/cluster-monitoring-operator/blob/aefc8fc5fc61c943dc1ca24b8c151940ae5f8f1c/assets/control-plane/prometheus-rule.yaml#L482-L490

--- a/alerts/KubePodNotReady.md
+++ b/alerts/KubePodNotReady.md
@@ -2,12 +2,12 @@
 
 ## Meaning
 
-[This alert][KubePodNotReady] is fired in case there are pods which have not
-been in `Ready` state for a certain period. This can have different reasons as
-described [here][PodLifecycle]: In case of the pod is `Running` but not `Ready`,
-the `Readiness` probe is failing. An application-specific error may prevent the
-pod from being attached to a service. In case the pod remains in `Pending`, it
-can not be deployed to particular namespaces and nodes.
+[This alert][KubePodNotReady] is fired when some pods have not been in the
+`Ready` state for a certain period. This can have different reasons as described
+[here][PodLifecycle]: When the pod is `Running` but not `Ready`, the `Readiness`
+probe is failing. An application-specific error may prevent the pod from being
+attached to a service. When the pod remains in `Pending` it can not be deployed
+to particular namespaces and nodes.
 
 ## Impact
 
@@ -33,7 +33,7 @@ Start by checking the status of the pod:
 $ oc get pod -n $NAMESPACE $POD
 ```
 
-If the pod state is in `Running`, you can check its logs:
+When the pod state is in `Running`, you can check its logs:
 
 ```console
 $ oc logs -n $NAMESPACE $POD
@@ -41,7 +41,7 @@ $ oc logs -n $NAMESPACE $POD
 
 Be aware there may be multiple containers in the pod. A check of all their logs
 may be required. If the pod isn't running (for instance, if it's stuck in
-ContainerCreating), then try to find out why.
+`ContainerCreating`), then try to find out why.
 
 ## Mitigation
 

--- a/alerts/KubePodNotReady.md
+++ b/alerts/KubePodNotReady.md
@@ -1,0 +1,51 @@
+# KubePodNotReady
+
+## Meaning
+
+[This alert][KubePodNotReady] is fired in case there are pods which have not
+been in `Ready` state for a certain period. This can have different reasons as
+described [here][PodLifecycle]: In case of the pod is `Running` but not `Ready`,
+the `Readiness` probe is failing. An application-specific error may prevent the
+pod from being attached to a service. In case the pod remains in `Pending`, it
+can not be deployed to particular namespaces and nodes.
+
+## Impact
+
+This pod is not functional and doesn't receive any traffic. Depending on how
+many functional replicas are still available, the impact differs.
+
+## Diagnosis
+
+The notification details should list the pod that's not ready (and the pod's
+namespace). E.g.:
+
+```text
+ - alertname = KubePodNotReady
+...
+ - namespace = openshift-logging
+ - pod = elasticsearch-cdm-u1gqqbu6-2-868ddd4b45-w224d
+...
+```
+
+Start by checking the status of the pod:
+
+```console
+$ oc get pod -n $NAMESPACE $POD
+```
+
+If the pod state is in `Running`, you can check its logs:
+
+```console
+$ oc logs -n $NAMESPACE $POD
+```
+
+Be aware there may be multiple containers in the pod. A check of all their logs
+may be required. If the pod isn't running (for instance, if it's stuck in
+ContainerCreating), then try to find out why.
+
+## Mitigation
+
+Try to find the issue in the logs before deleting it.
+
+[KubePodNotReady]: https://github.com/openshift/cluster-monitoring-operator/blob/aefc8fc5fc61c943dc1ca24b8c151940ae5f8f1c/assets/control-plane/prometheus-rule.yaml#L26-L41
+[PodLifecycle]: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/

--- a/alerts/NodeFilesystemFillingUP.md
+++ b/alerts/NodeFilesystemFillingUP.md
@@ -20,7 +20,12 @@ Study the recent trends of filesystem usage on a dashboard. Sometimes a periodic
 pattern of writing and cleaning up can trick the linear prediction into a false
 alert. Use the usual OS tools to investigate what directories are the worst
 and/or recent offenders. Is this some irregular condition, e.g. a process fails
-to clean up behind itself or is this organic growth?
+to clean up behind itself or is this organic growth? If monitoring is enabled,
+the following metric can be watched in PromQL.
+
+```console
+node_filesystem_free_bytes
+```
 
 Check the alert's `mountpoint` label.
 

--- a/alerts/NodeFilesystemFillingUP.md
+++ b/alerts/NodeFilesystemFillingUP.md
@@ -1,0 +1,57 @@
+# NodeFilesystemFillingUp
+
+## Meaning
+
+This alert is based on an extrapolation of the space used in a file system. It
+fires if both the current usage is above a certain threshold _and_ the
+extrapolation predicts to run out of space in a certain time. This is a
+warning-level alert if that time is less than 24h. It's a critical alert if that
+time is less than 4h.
+
+## Impact
+
+A filesystem running full is very bad for any process in need to write to the
+filesystem. But even before a filesystem runs full, performance is usually
+degrading.
+
+## Diagnosis
+
+Study the recent trends of filesystem usage on a dashboard. Sometimes a periodic
+pattern of writing and cleaning up can trick the linear prediction into a false
+alert. Use the usual OS tools to investigate what directories are the worst
+and/or recent offenders. Is this some irregular condition, e.g. a process fails
+to clean up behind itself or is this organic growth?
+
+Check the alert's `mountpoint` label.
+
+## Mitigation
+
+For the case that the `mountpoint` label is `/`, `/sysroot` or `/var`; then
+removing unused images solves that issue:
+
+Debug the node by accessing the node filesystem:
+
+```console
+$ NODE_NAME=<instance label from alert>
+$ oc -n default debug node/$NODE_NAME
+$ chroot /host
+```
+
+Remove dangling images:
+
+```console
+$ podman images -q -f dangling=true | xargs --no-run-if-empty podman rmi
+```
+
+Remove unused images:
+
+```console
+$ podman images | grep -v -e registry.redhat.io -e "quay.io/openshift" -e registry.access.redhat.com -e docker-registry.usersys.redhat.com -e docker-registry.ops.rhcloud.com -e rhmap | xargs --no-run-if-empty podman rmi 2>/dev/null
+```
+
+Exit debug:
+
+```console
+$ exit
+$ exit
+```

--- a/alerts/etcMemberDown.md
+++ b/alerts/etcMemberDown.md
@@ -10,10 +10,11 @@ reboot.
 ## Impact
 
 In etcd a majority of (n/2)+1 has to agree on membership changes or key-value
-upgrade proposals. By this, any split-brain inconsistency can be avoided. In the
-case that only one member is down in a 3-member cluster, it still can make
-forward progress since the quorum is 2 and 2 members are still alive. However,
-when more members are down, the cluster becomes unrecoverable.
+upgrade proposals. With this approach, a split-brain inconsistency can be
+avoided. In the case that only one member is down in a 3-member cluster, it
+still can make forward progress. Due to the fact that the quorum is 2 and 2
+members are still alive. However, when more members are down, the cluster
+becomes unrecoverable.
 
 ## Diagnosis
 
@@ -30,13 +31,12 @@ Check if an upgrade is in progress.
 $ oc adm upgrade
 ```
 
-In case there is no upgrade going on but there is a change in the
-`machineconfig` for the master pool causing rolling reboot of each master node,
-this alert can be triggered as well. We can check if the
+In case there is no upgrade going on, but there is a change in the
+`machineconfig` for the master pool causing a rolling reboot of each master
+node, this alert can be triggered as well. We can check if the
 `machineconfiguration.openshift.io/state : Working` annotation is set for any of
-the master nodes if
-[machine-config-operator](https://github.com/openshift/machine-config-operator)(MCO)
-is working on it.
+the master nodes. This is the case when the [machine-config-operator
+(MCO)](https://github.com/openshift/machine-config-operator) is working on it.
 
 ```console
 $ oc get nodes -l node-role.kubernetes.io/master= -o template --template='{{range .items}}{{"===> node:> "}}{{.metadata.name}}{{"\n"}}{{range $k, $v := .metadata.annotations}}{{println $k ":" $v}}{{end}}{{"\n"}}{{end}}'

--- a/alerts/etcMemberDown.md
+++ b/alerts/etcMemberDown.md
@@ -1,0 +1,54 @@
+# etcdMembersDown
+
+## Meaning
+
+This alert is fired when one or more etcd member goes down and evaluates the
+number of etcd members that are currently down. Often, this alert was observed
+as part of a cluster upgrade when a master node is being upgraded and requires a
+reboot.
+
+## Impact
+
+In etcd a majority of (n/2)+1 has to agree on membership changes or key-value
+upgrade proposals. By this, any split-brain inconsistency can be avoided. In the
+case that only one member is down in a 3-member cluster, it still can make
+forward progress since the quorum is 2 and 2 members are still alive. However,
+when more members are down, the cluster becomes unrecoverable.
+
+## Diagnosis
+
+Login to the cluster. Check health of master nodes if any of them is in
+`NotReady` state or not.
+
+```console
+$ oc get nodes -l node-role.kubernetes.io/master=
+```
+
+Check if an upgrade is in progress.
+
+```console
+$ oc adm upgrade
+```
+
+In case there is no upgrade going on but there is a change in the
+`machineconfig` for the master pool causing rolling reboot of each master node,
+this alert can be triggered as well. We can check if the
+`machineconfiguration.openshift.io/state : Working` annotation is set for any of
+the master nodes if
+[machine-config-operator](https://github.com/openshift/machine-config-operator)(MCO)
+is working on it.
+
+```console
+$ oc get nodes -l node-role.kubernetes.io/master= -o template --template='{{range .items}}{{"===> node:> "}}{{.metadata.name}}{{"\n"}}{{range $k, $v := .metadata.annotations}}{{println $k ":" $v}}{{end}}{{"\n"}}{{end}}'
+```
+
+## Mitigation
+
+If an upgrade is in progress, the alert may automatically resolve in some time
+when the master node comes up again. If MCO is not working on the master node,
+check the AWS to verify if the master node instances are running or not. AWS
+instance retirement might need a manual reboot of the master node.
+
+```console
+$ etcdctl endpoint health -w table
+```

--- a/alerts/etcdBackendQuotaLowSpace.md
+++ b/alerts/etcdBackendQuotaLowSpace.md
@@ -4,7 +4,7 @@
 
 This alert is fired when the total existing DB size exceeds 95% of the maximum
 DB quota. The consumed space is in Prometheus monitored by the metric
-`etcd_mvcc_db_total_size_in_bytes` and the DB quota size is defined by
+`etcd_mvcc_db_total_size_in_bytes`, and the DB quota size is defined by
 `etcd_server_quota_backend_bytes`.
 
 ## Impact
@@ -15,7 +15,7 @@ creation of pods.
 
 ## Diagnosis
 
-The following two approaches can be used for diagnosis.
+The following two approaches can be used for the diagnosis.
 
 ### CLI Checks
 
@@ -58,7 +58,7 @@ When the etcd DB size increases, we can defragment existing etcd DB to optimize
 DB consumption as described in [here][etcdDefragmentation]. Run the following
 command in all etcd pods.
 
-```console 
+```console
 $ etcdctl defrag
 ```
 

--- a/alerts/etcdBackendQuotaLowSpace.md
+++ b/alerts/etcdBackendQuotaLowSpace.md
@@ -1,0 +1,69 @@
+# etcdBackendQuotaLowSpace
+
+## Meaning
+
+This alert is fired when the total existing DB size exceeds 95% of the maximum
+DB quota. The consumed space is in Prometheus monitored by the metric
+`etcd_mvcc_db_total_size_in_bytes` and the DB quota size is defined by
+`etcd_server_quota_backend_bytes`.
+
+## Impact
+
+In case the DB size exceeds the DB quota, no writes can be performed anymore on
+the etcd cluster. This further prevents any updates in the cluster, such as the
+creation of pods.
+
+## Diagnosis
+
+The following two approaches can be used for diagnosis.
+
+### CLI Checks
+
+To run `etcdctl` commands, we need to `rsh` into the `etcdctl` container of any
+etcd pod.
+
+```console
+$ oc rsh -c etcdctl -n openshift-etcd $(oc get po -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
+```
+
+Validate that the `etcdctl` command is available:
+
+```console
+$ etcdctl version
+```
+
+`etcdctl` can be used to fetch the DB size of the etcd endpoints.
+
+```console
+$ etcdctl endpoint status -w table
+```
+
+### PromQL Checks
+
+Check the percentage consumption of etcd DB with the following query:
+
+```console
+(etcd_mvcc_db_total_size_in_bytes / etcd_server_quota_backend_bytes) * 100
+```
+
+Check the DB size in MB that can be reduced after defragmentation:
+
+```console
+(etcd_mvcc_db_total_size_in_bytes - etcd_mvcc_db_total_size_in_use_in_bytes)/1024/1024
+```
+
+## Mitigation
+
+When the etcd DB size increases, we can defragment existing etcd DB to optimize
+DB consumption as described in [here][etcdDefragmentation]. Run the following
+command in all etcd pods.
+
+```console 
+$ etcdctl defrag
+```
+
+As validation, check the endpoint status of etcd members to know the reduced
+size of etcd DB. Use for this purpose the same diagnostic approaches as listed
+above. More space should be available now.
+
+[etcdDefragmentation]: https://etcd.io/docs/v3.4.0/op-guide/maintenance/

--- a/example.md
+++ b/example.md
@@ -2,19 +2,29 @@
 
 ## Meaning
 
-This alert is based on an extrapolation of the space used in a file system. It fires if both the current usage is above a certain threshold _and_ the extrapolation predicts to run out of space in a certain time. This is a warning-level alert if that time is less than 24h. It's a critical alert if that time is less than 4h.
+This alert is based on an extrapolation of the space used in a file system. It
+fires if both the current usage is above a certain threshold _and_ the
+extrapolation predicts to run out of space in a certain time. This is a
+warning-level alert if that time is less than 24h. It's a critical alert if that
+time is less than 4h.
 
 ## Impact
 
-A filesystem running completely full is obviously very bad for any process in need to write to the filesystem. But even before a filesystem runs completely full, performance is usually degrading.
+A filesystem running completely full is obviously very bad for any process in
+need to write to the filesystem. But even before a filesystem runs completely
+full, performance is usually degrading.
 
 ## Diagnosis
 
-Study the recent trends of filesystem usage on a dashboard. Sometimes a periodic pattern of writing and cleaning up can trick the linear prediction into a false alert.
+Study the recent trends of filesystem usage on a dashboard. Sometimes a periodic
+pattern of writing and cleaning up can trick the linear prediction into a false
+alert.
 
-Use the usual OS tools to investigate what directories are the worst and/or recent offenders.
+Use the usual OS tools to investigate what directories are the worst and/or
+recent offenders.
 
-Is this some irregular condition, e.g. a process fails to clean up behind itself, or is this organic growth?
+Is this some irregular condition, e.g. a process fails to clean up behind
+itself, or is this organic growth?
 
 ## Mitigation
 


### PR DESCRIPTION
Here are 10 OCP alert runbook that could be open-sourced as an initial move.
Should probably be reviewed from SREs and product team. 
The first reference is the original runbook

The focus should hereby lie on:
The standardized structure of Meaning, Impact, Diagnosis, Mitigation, Reference.
Including some explanations about the implications to the infrastructure for educational purposes. 
Every step/command has explanations of what is happening.
Reading external links should only provide additional information and not be essential for resolving the issue.
