### PR TITLE
Add initial runbooks for all critical CMO alerts

### DIFF
--- a/alerts/cluster-monitoring-operator/AlertmanagerFailedReload.md
+++ b/alerts/cluster-monitoring-operator/AlertmanagerFailedReload.md
@@ -1,0 +1,24 @@
+# AlertmanagerFailedReload
+
+## Meaning
+
+The alert `AlertmanagerFailedReload` is triggered when the Alertmanager instance
+for the cluster monitoring stack has consistently failed to reload its
+configuration for a certain period.
+
+## Impact
+
+Alerts for cluster components may not be delivered as expected.
+
+## Diagnosis
+
+Check the logs for the `alertmanager-main` pods in the `openshift-monitoring`
+namespace:
+
+```console
+$ oc -n openshift-monitoring logs -l 'alertmanager=main'
+```
+
+## Mitigation
+
+The resolution depends on the particular issue reported in the logs.

--- a/alerts/cluster-monitoring-operator/KubeAPIDown.md
+++ b/alerts/cluster-monitoring-operator/KubeAPIDown.md
@@ -1,0 +1,35 @@
+# KubeAPIDown
+
+## Meaning
+
+The `KubeAPIDown` alert is triggered when all Kubernetes API servers have not
+been reachable by the monitoring system for more than 15 minutes.
+
+## Impact
+
+This is a critical alert. The Kubernetes API is not responding. The
+cluster may partially or fully non-functional.
+
+## Diagnosis
+
+Check the status of the API server targets in the Prometheus UI.
+
+Then, confirm whether the API is also unresponsive for you:
+
+```console
+$ oc cluster-info
+```
+
+If you can still reach the API server, there may be a network issue between the
+Prometheus instances and the API server pods. Check the status of the API server
+pods:
+
+```console
+$ oc -n openshift-kube-apiserver get pods
+$ oc -n openshift-kube-apiserver logs -l 'app=openshift-kube-apiserver'
+```
+## Mitigation
+
+If you can still reach the API server intermittently, you may be able treat this
+like any other failing deployment. If not, it's possible you may have to refer
+to the disaster recovery documentation for your version of OpenShift.

--- a/alerts/cluster-monitoring-operator/KubePersistentVolumeFillingUp.md
+++ b/alerts/cluster-monitoring-operator/KubePersistentVolumeFillingUp.md
@@ -1,0 +1,50 @@
+# KubePersistentVolumeFillingUp
+
+## Meaning
+
+This alert fires when a persistent volume in one of the system namespaces,
+i.e. a namespace beginning with `openshift-`, `kube-`, or the `default`
+namespace, has less than 3% of its total space left.
+
+## Impact
+
+A full persistent volume used by a system component is likely to prevent the
+component from functioning normally, and may lead to a partial or full cluster
+outage.
+
+## Diagnosis
+
+The alert labels should include the name of the PersistentVolumeClaim associated
+with the volume that is low on storage, as well as the namespace that claim is
+in.  You can use these to graph the available storage in the OpenShift web
+console under Observer -> Metrics.  The following is an example query for a
+volume claim associated with a Prometheus instance in the `openshift-monitoring`
+namespace:
+
+```text
+kubelet_volume_stats_available_bytes{
+  namespace="openshift-monitoring",
+  persistentvolumeclaim="prometheus-k8s-db-prometheus-k8s-0"
+}
+```
+
+You can inspect the contents of the volume manually to determine what is using
+the storage:
+
+```console
+$ PVC_NAME='<persistentvolumeclaim label from alert>'
+$ NAMESPACE='<namespace label from alert>'
+
+$ oc -n $NAMESPACE describe pvc $PVC_NAME
+$ POD_NAME='<"Used By:" field from the above output>'
+
+$ oc -n $NAMESPACE rsh $POD_NAME
+$ df -h
+```
+
+## Mitigation
+
+The mitigation largely depends on what is using the storage.  You may be able to
+simply allocate more storage to the affected volume, or adjust the configuration
+for the component using the volume to use less space -- for instance by lowering
+a logging level or similar.

--- a/alerts/cluster-monitoring-operator/KubeletDown.md
+++ b/alerts/cluster-monitoring-operator/KubeletDown.md
@@ -1,0 +1,38 @@
+# KubeletDown
+
+## Meaning
+
+This alert is triggered when the monitoring system has not been able to reach
+any of the cluster's Kubelets for more than 15 minutes.
+
+## Impact
+
+This alert represents a critical threat to the cluster's stability. Excluding
+the possibility of a network issue preventing the monitoring system from
+scraping Kubelet metrics, multiple nodes in the cluster are likely unable to
+respond to configuration changes for pods and other resources, and some
+debugging tools are likely not functional, e.g. `oc exec` and `oc logs`.
+
+## Diagnosis
+
+Check the status of nodes and for recent events on `Node` objects, or for recent
+events in general:
+
+```console
+$ oc get nodes
+$ oc describe node $NODE_NAME
+$ oc get events --field-selector 'involvedObject.kind=Node'
+$ oc get events
+```
+
+If you have SSH access to the nodes, access the logs for the Kubelet directly:
+
+```console
+$ journalctl -b -f -u kubelet.service
+```
+
+## Mitigation
+
+The mitigation depends on what is causing the Kubelets to become
+unresponsive. Check for wide-spread networking issues, or node level
+configuration issues.

--- a/alerts/cluster-monitoring-operator/NodeFileDescriptorLimit.md
+++ b/alerts/cluster-monitoring-operator/NodeFileDescriptorLimit.md
@@ -1,0 +1,33 @@
+# NodeFileDescriptorLimit
+
+## Meaning
+
+This alert is triggered when a node's kernel is found to be running out of
+available file descriptors -- a `warning` level alert at greater than 70% usage
+and a `critical` level alert at greater than 90% usage.
+
+## Impact
+
+Applications on the node may no longer be able to open and operate on
+files. This is likely to have severe consequences for anything scheduled on this
+node.
+
+## Diagnosis
+
+You can open a shell on the node and use the standard Linux utilities to
+diagnose the issue:
+
+```console
+$ NODE_NAME='<value of instance label from alert>'
+
+$ oc debug "node/$NODE_NAME"
+# sysctl -a | grep 'fs.file-'
+fs.file-max = 1597016
+fs.file-nr = 7104       0       1597016
+# lsof -n
+```
+
+## Mitigation
+
+Reduce the number of files opened simultaneously by either adjusting application
+configuration or by moving some applications to other nodes.

--- a/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfFiles.md
+++ b/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfFiles.md
@@ -1,0 +1,27 @@
+# NodeFilesystemAlmostOutOfFiles
+
+## Meaning
+
+This alert is similar to the [NodeFilesystemSpaceFillingUp][1] alert, but rather
+than being based on a prediction that a filesystem will run out of inodes in a
+certain amount of time, it uses simple static thresholds. The alert will fire as
+at a `warning` level at 5% of available inodes left, and at a `critical` level
+with 3% of available inodes left.
+
+## Impact
+
+A node's filesystem becoming full can have a far reaching impact, as it may
+cause any or all of the applications scheduled to that node to experience
+anything from performance degradation to full inoperability. Depending on the
+node and filesystem involved, this could pose a critical threat to the stability
+of the cluster.
+
+## Diagnosis
+
+Refer to the [NodeFilesystemFilesFillingUp][1] runbook.
+
+## Mitigation
+
+Refer to the [NodeFilesystemFilesFillingUp][1] runbook.
+
+[1]: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md

--- a/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+++ b/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
@@ -1,0 +1,26 @@
+# NodeFilesystemAlmostOutOfSpace
+
+## Meaning
+
+This alert is similar to the [NodeFilesystemSpaceFillingUp][1] alert, but rather
+than being based on a prediction that a filesystem will become full in a certain
+amount of time, it uses simple static thresholds. The alert will fire as at a
+`warning` level at 5% space left, and at a `critical` level with 3% space left.
+
+## Impact
+
+A node's filesystem becoming full can have a far reaching impact, as it may
+cause any or all of the applications scheduled to that node to experience
+anything from performance degradation to full inoperability. Depending on the
+node and filesystem involved, this could pose a critical threat to the stability
+of the cluster.
+
+## Diagnosis
+
+Refer to the [NodeFilesystemSpaceFillingUp][1] runbook.
+
+## Mitigation
+
+Refer to the [NodeFilesystemSpaceFillingUp][1] runbook.
+
+[1]: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md

--- a/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
+++ b/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
@@ -1,0 +1,53 @@
+# NodeFilesystemFilesFillingUp
+
+## Meaning
+
+This alert is similar to the [NodeFilesystemSpaceFillingUp][1] alert, but
+predicts the filesystem will run out of inodes rather than bytes of storage
+space. The alert fires at a `critical` level when the filesystem is predicted to
+run out of available inodes within four hours.
+
+## Impact
+
+A node's filesystem becoming full can have a far reaching impact, as it may
+cause any or all of the applications scheduled to that node to experience
+anything from performance degradation to full inoperability. Depending on the
+node and filesystem involved, this could pose a critical threat to the stability
+of the cluster.
+
+## Diagnosis
+
+Note the `instance` and `mountpoint` labels from the alert. You can graph the
+usage history of this filesystem with the following query in the OpenShift web
+console:
+
+```text
+node_filesystem_files_free{
+  instance="<value of instance label from alert>",
+  mountpoint="<value of mountpoint label from alert>"
+}
+```
+
+You can also open a debug session on the node and use the standard Linux
+utilities to locate the source of the usage:
+
+```console
+$ MOUNT_POINT='<value of mountpoint label from alert>'
+$ NODE_NAME='<value of instance label from alert>'
+
+$ oc debug "node/$NODE_NAME"
+$ df -hi "/host/$MOUNT_POINT"
+```
+
+Note that in many cases a filesystem running out of inodes will still have
+available storage. Running out of inodes is often caused by many many small
+files being created by an application.
+
+## Mitigation
+
+The number of inodes allocated to a filesystem is usually based on the storage
+size. You may be able to solve the problem, or buy time, by increasing size of
+the storage volume. Otherwise, determine the application that is creating large
+numbers of files and adjust its configuration or provide it dedicated storage.
+
+[1]: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md

--- a/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md
+++ b/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md
@@ -1,4 +1,4 @@
-# NodeFilesystemFillingUp
+# NodeFilesystemSpaceFillingUp
 
 ## Meaning
 

--- a/alerts/cluster-monitoring-operator/NodeRAIDDegraded.md
+++ b/alerts/cluster-monitoring-operator/NodeRAIDDegraded.md
@@ -1,0 +1,32 @@
+# NodeRAIDDegraded
+
+## Meaning
+
+This alert is triggered when a node has a storage configuration with RAID array,
+and the array is reporting as being in a degraded state due to one or more disk
+failures.
+
+## Impact
+
+The affected node could go offline at any moment if the RAID array fully fails
+due to further issues with disks.
+
+## Diagnosis
+
+You can open a shell on the node and use the standard Linux utilities to
+diagnose the issue, but you may need to install additional software in the debug
+container:
+
+```console
+$ NODE_NAME='<value of instance label from alert>'
+
+$ oc debug "node/$NODE_NAME"
+$ cat /proc/mdstat
+```
+
+## Mitigation
+
+See the Red Hat Enterprise Linux [documentation][2].
+
+[1]: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
+[2]: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_storage_devices/managing-raid_managing-storage-devices

--- a/alerts/cluster-monitoring-operator/PrometheusTargetSyncFailure.md
+++ b/alerts/cluster-monitoring-operator/PrometheusTargetSyncFailure.md
@@ -1,0 +1,32 @@
+# PrometheusTargetSyncFailure
+
+## Meaning
+
+This alert is triggered when at least one of the Prometheus instances has
+consistently failed to sync its configuration.
+
+## Impact
+
+Metrics and alerts may be missing or inaccurate.
+
+## Diagnosis
+
+Determine whether the alert is for the cluster or user workload Prometheus by
+inspecting the alert's `namespace` label. The namespace for the cluster
+Prometheus is `openshift-monitoring`, while the namespace for the user workload
+monitoring instance is `openshift-user-workload-monitoring`.
+
+Check the logs for the appropriate Prometheus instance:
+
+```console
+$ NAMESPACE='<value of namespace label from alert>'
+
+$ oc -n $NAMESPACE logs -l 'app=prometheus'
+level=error ... msg="Creating target failed" ...
+```
+
+## Mitigation
+
+If the logs indicate a syntax or other configuration error, correct the
+corresponding `ServiceMonitor`, `PodMonitor`, or other configuration
+resource. In most all cases, the operator should prevent this from happening.

--- a/alerts/cluster-monitoring-operator/ThanosRuleQueueIsDroppingAlerts.md
+++ b/alerts/cluster-monitoring-operator/ThanosRuleQueueIsDroppingAlerts.md
@@ -1,0 +1,38 @@
+# ThanosRuleQueueIsDroppingAlerts
+
+## Meaning
+
+The [Thanos Ruler][1] is deployed when user workload monitoring is enabled. It
+allows alerting rules deployed as part of user workload monitoring to query both
+the the Prometheus instance responsible for cluster components as well the user
+workload Prometheus instance. This alert is triggered when the Thanos Ruler
+queue is found to be dropping alerting events.
+
+## Impact
+
+Alerts for user workloads may not be delivered.
+
+## Diagnosis
+
+Check the logs for the Thanos Rules pods:
+
+```console
+$ oc -n openshift-user-workload-monitoring logs -l 'thanos-ruler=user-workload'
+...
+level=warn ... msg="Alert notification queue full, dropping alerts" numDropped=100
+level=warn ... msg="Alert batch larger than queue capacity, dropping alerts" numDropped=100
+```
+
+If this alert has triggered, you likely have an extremely large number of alerts
+flowing from the user workload monitoring stack. Log into the OpenShift web
+console and check the active alerts.
+
+## Mitigation
+
+The default queue capacity for Thanos Ruler is quite high at 10,000 items,
+meaning the most likely scenario is a misconfiguration causing the user workload
+monitoring stack to overload Thanos Ruler with duplicate or otherwise erroneous
+alerts. Check the active alerts in the OpenShift web console, and correct any
+misconfigurations or consider grouping alerts.
+
+[1]: https://thanos.io/v0.22/components/rule.md


### PR DESCRIPTION
This adds at least a basic outline of a runbook for every critical alert shipped
by the cluster-monitoring-operator as of the OpenShift 4.9 release.  Most of
these are very incomplete, but this is a starting point.

Context: https://issues.redhat.com/browse/MON-1645