### PR TITLE
fix(KubeAPIErrorBudgetBurn): change variable name

### DIFF
--- a/alerts/cluster-kube-apiserver-operator/KubeAPIErrorBudgetBurn.md
+++ b/alerts/cluster-kube-apiserver-operator/KubeAPIErrorBudgetBurn.md
@@ -132,9 +132,9 @@ E.g. to determine who generate the `apirequestcount` resource slow requests and
 what these requests are doing:
 
 ```sh
-oc dev_tool audit -f ${kube-apiserver-audit-log-dir} -otop --by=user resource="apirequestcounts"
+oc dev_tool audit -f ${kube_apiserver_audit_log_dir} -otop --by=user resource="apirequestcounts"
 
-oc dev_tool audit -f ${kube-apiserver-audit-log-dir} -otop --by=verb resource="apirequestcounts" --user=${top-user-from-last-command}
+oc dev_tool audit -f ${kube_apiserver_audit_log_dir} -otop --by=verb resource="apirequestcounts" --user=${top-user-from-last-command}
 ```
 
 The `audit` subcommand also supports the `--failed-only` option which can be
@@ -142,13 +142,13 @@ used to return failed requests only:
 
 ```sh
 # find the top-10 users with the highest failed requests count
-oc dev_tool audit -f ${kube-apiserver-audit-log-dir} --by user --failed-only -otop
+oc dev_tool audit -f ${kube_apiserver_audit_log_dir} --by user --failed-only -otop
 
 # find the top-10 failed API resource calls of a specific user
-oc dev_tool audit -f ${kube-apiserver-audit-log-dir} --by resource --user=${service_account} --failed-only -otop
+oc dev_tool audit -f ${kube_apiserver_audit_log_dir} --by resource --user=${service_account} --failed-only -otop
 
 # find the top-10 failed API verbs of a specific user on a specific resource
-oc dev_tool audit -f ${kube-apiserver-audit-log-dir} --by verb --user=${service_account} --resource=${resources} --failed-only -otop
+oc dev_tool audit -f ${kube_apiserver_audit_log_dir} --by verb --user=${service_account} --resource=${resources} --failed-only -otop
 ```
 
 When filing a new Bugzilla issue, be sure to attach this information and the


### PR DESCRIPTION
this way when copy pasting, you can set the var once and the command will suceed