### PR TITLE
Bug 2010719: alerts/cluster-etcd-operator/etcdHighNumberOfFailedGRPCRequests.md: Init

### DIFF
--- a/alerts/cluster-etcd-operator/etcdHighNumberOfFailedGRPCRequests.md
+++ b/alerts/cluster-etcd-operator/etcdHighNumberOfFailedGRPCRequests.md
@@ -1,0 +1,62 @@
+# etcdHighNumberOfFailedGRPCRequests
+
+## Meaning
+
+This alert fires when at least 50% of etcd gRPC requests failed in the past 10
+minutes.
+
+## Impact
+
+First establish which gRPC method is failing, this will be visible in the alert.
+If it's not part of the alert, the following query will display method and etcd
+instance that has failing requests:
+
+```sh
+100 * sum without(grpc_type, grpc_code)
+(rate(grpc_server_handled_total{grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded",job="etcd"}[5m]))
+/ sum without(grpc_type, grpc_code)
+(rate(grpc_server_handled_total{job="etcd"}[5m])) > 5 and on()
+(sum(cluster_infrastructure_provider{type!~"ipi|BareMetal"} == bool 1))
+```
+
+## Diagnosis
+
+All the gRPC errors should also be logged in each respective etcd instance logs.
+You can get the instance name from the alert that is firing or by running the
+query detailed above. Those etcd instance logs should serve as further insight
+into what is wrong.
+
+To get logs of etcd containers either check the instance from the alert and
+check logs directly or run the following:
+
+```sh
+oc logs -n openshift-etcd -lapp=etcd etcd
+```
+
+### Defrag method errors
+
+If defrag method is failing, this could be due to defrag that is periodically
+performed by cluster-etcd-operator pe starting from OpenShift v4.9 onwards. To
+verify this check the logs of cluster-etcd-operator.
+
+```sh
+oc logs -l app=etcd-operator -n openshift-etcd-operator --tail=-1
+```
+
+If you have run defrag manually on older OpenShift versions check the errors of
+those manual runs.
+
+### MemberList method errors
+
+Member list is most likely performed by cluster-etcd-operator, so it's also best
+to check also logs of cluster-etcd-operator for any errors:
+
+```sh
+oc logs -l app=etcd-operator -n openshift-etcd-operator --tail=-1
+```
+
+## Mitigation
+
+Depending on the above diagnosis, the issue will most likely be described in the
+error log line of either etcd or openshift-etcd-operator. Most likely causes
+tend to be networking issues.


### PR DESCRIPTION
Add initial runbook, which can be improved as we get reports from
customers and SRE folks.

This is a brand new alert and has not been firing often on clusters and it's not firing often, but I included Defrag as I have seen it fire while I was testing.

![Screenshot 2021-10-07 at 11 50 14](https://user-images.githubusercontent.com/6232346/136361756-60230ba1-18d3-4c99-a2f3-662092c0cbcc.png)

@hexfusion @hasbro17 please take a look, improvements welcome!