### PR TITLE
alerts/cluster-etcd-operator/etcdGRPCRequestsSlow.md: Improve

### DIFF
--- a/alerts/cluster-etcd-operator/etcdGRPCRequestsSlow.md
+++ b/alerts/cluster-etcd-operator/etcdGRPCRequestsSlow.md
@@ -45,7 +45,7 @@ which will assist with further issues.
 
 ### Resource exhaustion
 
-It can happen that due to CPU resource exhaustion that etcd responds slower.
+It can happen that etcd responds slower due to CPU resource exhaustion.
 This was seen in some cases when one application was requesting too much CPU
 which led to this alert firing for multiple methods.
 


### PR DESCRIPTION
Add CPU resource exhaustion to the runbook.

Query that is used is the same console uses and you can clearly see which is the main at fault:

![Screenshot 2021-10-15 at 15 24 06](https://user-images.githubusercontent.com/6232346/137494094-795fd40b-18bc-477e-a5a1-79e1d5f5651e.png)

@hexfusion @hasbro17 @RiRa12621 please take a look, thanks!