### PR TITLE
[MON-1941]: Runbooks for FailedToSendAlerts alert

### DIFF
--- a/alerts/cluster-monitoring-operator/AlertmanagerClusterFailedToSendAlerts.md
+++ b/alerts/cluster-monitoring-operator/AlertmanagerClusterFailedToSendAlerts.md
@@ -1,0 +1,29 @@
+# AlertmanagerClusterFailedToSendAlerts
+
+## Meaning
+
+The alert `AlertmanagerClusterFailedToSendAlerts` is triggered when **all**
+Alertmanager instances in a cluster has consistently failed to send
+notifications to an integration.
+
+## Impact
+
+A fraction of notifications to the integration are not delivered.
+
+## Diagnosis
+
+Check the logs of the `alertmanager-main` pods in the `openshift-monitoring`
+namespace:
+
+
+```console
+$ oc -n openshift-monitoring logs -l 'alertmanager=main'
+```
+
+Below is a non-exhaustive list of reasons for this alert to be fired.
+- Unreachable endpoint
+- Misconfigured address or credentials
+
+## Mitigation
+
+The resolution depends on the particular issue reported in the logs.

--- a/alerts/cluster-monitoring-operator/AlertmanagerFailedToSendAlerts.md
+++ b/alerts/cluster-monitoring-operator/AlertmanagerFailedToSendAlerts.md
@@ -1,0 +1,27 @@
+# AlertmanagerFailedToSendAlerts
+
+## Meaning
+
+The alert `AlertmanagerFailedToSendAlerts` is triggered when any of the
+Alertmanager instances of the cluster monitoring stack has consistently
+failed to send notifications to an integration.
+
+## Impact
+
+Some of the notifcations are not delivered.
+
+## Diagnosis
+
+Check the logs of the `alertmanager-main` pod in `openshift-monitoring` namespace
+in the alert description. E.g. If the Alert description says
+
+> Alertmanager openshift-monitoring/alertmanager-main-1 failed to send 75%
+> of notifications to webhook.
+
+```console
+$ oc -n openshift-monitoring logs alertmanager-main-1
+```
+
+## Mitigation
+
+The resolution depends on the particular issue reported in the logs.


### PR DESCRIPTION
Adds two Runbooks for `AlertmanagerFailedReload` and `AlertmanagerClusterFailedToSendAlerts` alerts