### PR TITLE
Diagnostic commands fixes for cluster-etcd-operator

### DIFF
--- a/alerts/cluster-etcd-operator/etcdBackendQuotaLowSpace.md
+++ b/alerts/cluster-etcd-operator/etcdBackendQuotaLowSpace.md
@@ -23,7 +23,7 @@ To run `etcdctl` commands, we need to `rsh` into the `etcdctl` container of any
 etcd pod.
 
 ```console
-$ oc rsh -c etcdctl -n openshift-etcd $(oc get po -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
+$ oc rsh -c etcdctl -n openshift-etcd $(oc get pod -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
 ```
 
 Validate that the `etcdctl` command is available:

--- a/alerts/cluster-etcd-operator/etcdHighNumberOfFailedGRPCRequests.md
+++ b/alerts/cluster-etcd-operator/etcdHighNumberOfFailedGRPCRequests.md
@@ -30,7 +30,7 @@ To get logs of etcd containers either check the instance from the alert and
 check logs directly or run the following:
 
 ```sh
-oc logs -n openshift-etcd -lapp=etcd etcd
+oc logs -n openshift-etcd -lapp=etcd -c etcd
 ```
 
 ### Defrag method errors

--- a/alerts/cluster-etcd-operator/etcdInsufficientMembers.md
+++ b/alerts/cluster-etcd-operator/etcdInsufficientMembers.md
@@ -50,7 +50,7 @@ To run `etcdctl` commands, we need to `rsh` into the `etcdctl` container of any
 etcd pod.
 
 ```console
-$ oc rsh -c etcdctl -n openshift-etcd $(oc get po -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
+$ oc rsh -c etcdctl -n openshift-etcd $(oc get pod -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
 ```
 
 Validate that the `etcdctl` command is available:

--- a/alerts/cluster-etcd-operator/etcdMembersDown.md
+++ b/alerts/cluster-etcd-operator/etcdMembersDown.md
@@ -48,7 +48,7 @@ To run `etcdctl` commands, we need to `rsh` into the `etcdctl` container of any
 etcd pod.
 
 ```console
-$ oc rsh -c etcdctl -n openshift-etcd $(oc get po -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
+$ oc rsh -c etcdctl -n openshift-etcd $(oc get pod -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
 ```
 
 Validate that the `etcdctl` command is available:


### PR DESCRIPTION
When following the rsh step into the etcd pod I ran into an issue that was likely caused by the performance issue but it was complaining about resource "po" not existing, if "po" is replaced by "pod" it will be less confusing and prevent the suspicion of the diagnostic steps being mistaken.

Also added container selector in [etcdHighNumberOfFailedGRPCRequests.md](https://github.com/openshift/runbooks/commit/6b904166b4bbb2fea78a098326b0af3460018583#diff-8f38595acc109772fc686df2d1d664531915c14c3f72633f3757614366dfb142) as the command is receiving a label and a pod name without that option.