### PR TITLE
RFE-2703: add prometheus rules for master memory usage

### DIFF
--- a/alerts/machine-config-operator/ExtremelyHighIndividualControlPlaneMemory.md
+++ b/alerts/machine-config-operator/ExtremelyHighIndividualControlPlaneMemory.md
@@ -1,0 +1,27 @@
+# ExtremelyHighIndividualControlPlaneMemory
+
+## Meaning
+
+This alert fires when the memory use by an instance within control plane
+nodes exceeds 90% of total memory available on that node.  
+This is a critical level alert.
+
+## Impact
+
+At such very low free memory, the cluster becomes unstable you can expect slow
+responses from kube-apiserver or failing requests specially from etcd.
+Moreover, OOM kill is expected, which negatively influences the pod scheduling.
+
+## Diagnosis
+
+To fix this, increase memory of the affected node of control plane nodes.
+
+## Mitigation
+
+Responding to a `HighOverallControlPlaneMemory` alert can mitigate this situation.
+`HighOverallControlPlaneMemory` is a warning level alert, which fires
+when the total memory usage across all
+control-plane nodes crosses 60% for more than 1 hour.
+
+You could scale up the memory of the control plane node if this situation
+stays up for long time to prevent the critical alert from firing.

--- a/alerts/machine-config-operator/OWNERS
+++ b/alerts/machine-config-operator/OWNERS
@@ -1,0 +1,14 @@
+approvers:
+  - cgwalters
+  - kikisdeliveryservice
+  - sinnykumari
+  - yuqi-zhang
+reviewers:
+  - cgwalters
+  - kikisdeliveryservice
+  - sinnykumari
+  - yuqi-zhang
+  - cheesesashimi
+  - jkyros
+
+component: "Machine Config Operator"


### PR DESCRIPTION
This PR adds a Runbook for the critical alert `ExtremelyHighIndividualControlPlaneMemory` 

see https://github.com/openshift/machine-config-operator/pull/3124