### PR TITLE
Fix linting setup

### DIFF
--- a/hack/install-markdownlint.sh
+++ b/hack/install-markdownlint.sh
@@ -2,4 +2,4 @@
 
 dnf -y module enable nodejs:12
 dnf -y install nodejs
-npm install -g markdownlint markdownlint-cli2
+npm install -g markdownlint@0.26.0 markdownlint-cli2@0.4.0


### PR DESCRIPTION
The linter currently seems a bit sad:

```
Error: Cannot find module 'node:path'
```

Some cursory research suggested this is a problem introduced in a recently-published version of markdownlint which is incompatible with nodejs 12.

This PR temporarily locks `markdownlint` and `markdownlint-cli` at a version that will work, whilst I pursue a more permanent fix in the release CI repo. At the moment, I can't fix the release CI repo because the PR rehearsals are failing for the same reason.