### PR TITLE
Fix wrong links

### DIFF
--- a/alerts/cluster-etcd-operator/etcdInsufficientMembers.md
+++ b/alerts/cluster-etcd-operator/etcdInsufficientMembers.md
@@ -77,6 +77,6 @@ a manual reboot of the master node.
 
 As a last resort if none of the above fix the issue and the alert is still
 firing, for etcd specific issues follow the steps described in the [disaster and
-recovery docs](docs).
+recovery docs][docs].
 
-[docs]:(https://docs.openshift.com/container-platform/4.7/backup_and_restore/disaster_recovery/about-disaster-recovery.html).
+[docs]: https://docs.openshift.com/container-platform/4.7/backup_and_restore/disaster_recovery/about-disaster-recovery.html

--- a/alerts/cluster-etcd-operator/etcdNoLeader.md
+++ b/alerts/cluster-etcd-operator/etcdNoLeader.md
@@ -38,7 +38,7 @@ namespace/project and in the `etcd` container.
 
 ### Disaster and recovery
 
-Follow the steps described in the [disaster and recovery docs](docs).
+Follow the steps described in the [disaster and recovery docs][docs].
 
 
-[docs]:(https://docs.openshift.com/container-platform/4.7/backup_and_restore/disaster_recovery/about-disaster-recovery.html).
+[docs]: https://docs.openshift.com/container-platform/4.7/backup_and_restore/disaster_recovery/about-disaster-recovery.html

--- a/alerts/cluster-monitoring-operator/NodeRAIDDegraded.md
+++ b/alerts/cluster-monitoring-operator/NodeRAIDDegraded.md
@@ -26,7 +26,6 @@ $ cat /proc/mdstat
 
 ## Mitigation
 
-See the Red Hat Enterprise Linux [documentation][2].
+See the Red Hat Enterprise Linux [documentation][1].
 
-[1]: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
-[2]: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_storage_devices/managing-raid_managing-storage-devices
+[1]: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_storage_devices/managing-raid_managing-storage-devices


### PR DESCRIPTION
The latest version of `markdownlint-cli2` found a few links that were
either invalid or not correctly formatted. We need to fix them before
considering upgrading the version of `markdownlint-cli2`.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>