### PR TITLE
alerts/cluster-monitoring-operator/KubeletDown: Mention 'oc adm node-logs ...'

### DIFF
--- a/alerts/cluster-monitoring-operator/KubeletDown.md
+++ b/alerts/cluster-monitoring-operator/KubeletDown.md
@@ -26,8 +26,17 @@ $ oc get events --field-selector 'involvedObject.kind=Node'
 $ oc get events
 ```
 
-If you have SSH access to the nodes, use this access to review the logs for the
-Kubelet:
+You can [access cluster node journal logs][cluster-node-journal-logs] to review
+the logs for the Kubelet.  If the Kubelet is functional, you can use:
+
+```console
+$ oc adm node-logs --role=master -u kubelet
+```
+
+See `oc adm node-logs --help` for alternative ways to select nodes and filter results.
+
+If the kubelet is not functional and you have SSH access to the nodes,
+use this access to review the logs for the Kubelet:
 
 ```console
 $ journalctl -b -f -u kubelet.service
@@ -38,3 +47,5 @@ $ journalctl -b -f -u kubelet.service
 The mitigation for this alert depends on the issue causing the Kubelets to
 become unresponsive. You can begin by checking for general networking issues or
 for node-level configuration issues.
+
+[cluster-node-journal-logs]: https://docs.openshift.com/container-platform/latest/support/gathering-cluster-data.html#querying-cluster-node-journal-logs_gathering-cluster-data


### PR DESCRIPTION
SSH is useful if the kubelet is too dead to serve logs.  But in some cases like busted monitoring cert issues, the kubelet is up and the `KubeletDown` alerts are [purely monitoring-side][1]:

```console
$ oc adm node-logs --role=master -u kubelet | grep -i ' [IWE]1219' | grep -v 'I1219' | tail -n4
Dec 19 23:59:55.095722 build0-gstfj-m-2.c.openshift-ci-build-farm.internal kubenswrapper[2629]: E1219 23:59:55.095660    2629 server.go:291] "Unable to authenticate the request due to an error" err="verifying certificate SN=..., SKID=, AKID=... failed: x509: certificate signed by unknown authority"
Dec 19 23:59:55.280665 build0-gstfj-m-2.c.openshift-ci-build-farm.internal kubenswrapper[2629]: E1219 23:59:55.280603    2629 server.go:291] "Unable to authenticate the request due to an error" err="verifying certificate SN=..., SKID=, AKID=... failed: x509: certificate signed by unknown authority"
Dec 19 23:59:55.911169 build0-gstfj-m-2.c.openshift-ci-build-farm.internal kubenswrapper[2629]: E1219 23:59:55.911104    2629 server.go:291] "Unable to authenticate the request due to an error" err="verifying certificate SN=..., SKID=, AKID=... failed: x509: certificate signed by unknown authority"
Dec 19 23:59:59.291282 build0-gstfj-m-2.c.openshift-ci-build-farm.internal kubenswrapper[2629]: E1219 23:59:59.291211    2629 server.go:291] "Unable to authenticate the request due to an error" err="verifying certificate SN=..., SKID=, AKID=... failed: x509: certificate signed by unknown authority"
```

[1]: https://issues.redhat.com/browse/OCPBUGS-4521