### PR TITLE
Add NodeStatusMaxImagesExceeded runbook

### DIFF
--- a/alerts/openshift-virtualization-operator/NodeStatusMaxImagesExceeded.md
+++ b/alerts/openshift-virtualization-operator/NodeStatusMaxImagesExceeded.md
@@ -1,0 +1,32 @@
+# NodeStatusMaxImagesExceeded
+
+## Meaning
+
+This alert fires when a node exceeds the configured maximum number of images
+reported in the node status (default: 50). Once this limit is reached, the
+scheduler might not be able to accurately schedule new pods because the reported
+image count is wrong.
+
+## Impact
+
+Pod scheduling might be imbalanced across nodes.
+
+## Diagnosis
+
+1. Obtain the image count for the node:
+
+   ```bash
+   $ oc get nodes <node> -o jsonpath='{range .status.images[*]}{.names}{"\n"}{end}' | wc -l
+   ```
+
+2. If the image count is equal to the default (50) or to a configured value,
+you must resolve the issue.
+
+## Mitigation
+
+You can either increase the `nodeStatusMaxImages` value of the `KubeletConfig`
+object or set its value to `-1` to disable the maximum image limit.
+
+If you cannot resolve the issue, log in to the
+[Customer Portal](https://access.redhat.com) and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.


### PR DESCRIPTION
This PR adds a runbook for the OpenShift virtualization operator `NodeStatusMaxImagesExceeded` alert