### PR TITLE
Reference Bug in NodeStatusMaxImagesExceeded

### DIFF
--- a/alerts/openshift-virtualization-operator/NodeStatusMaxImagesExceeded.md
+++ b/alerts/openshift-virtualization-operator/NodeStatusMaxImagesExceeded.md
@@ -5,7 +5,7 @@
 This alert fires when a node exceeds the configured maximum number of images
 reported in the node status (default: 50). Once this limit is reached, the
 scheduler might not be able to accurately schedule new pods because the reported
-image count is wrong.
+image count is wrong. [BZ#1984442](https://bugzilla.redhat.com/1984442)
 
 ## Impact
 


### PR DESCRIPTION
To provide the user more context, a reference to the related bug is added to the runbook.