### PR TITLE
Correct SSPDown runbook file name and headline

### DIFF
--- a/alerts/openshift-virtualization-operator/SSPDown.md
+++ b/alerts/openshift-virtualization-operator/SSPDown.md
@@ -1,4 +1,4 @@
-# SSPOperatorDown
+# SSPDown
 
 ## Meaning
 


### PR DESCRIPTION
Currently, [SSPDown alert](https://github.com/kubevirt/ssp-operator/blob/master/internal/operands/metrics/resources.go#L82) has a runbook URL with the name SSPOperatorDown. 
This PR changes this runbook file name and headline.

Signed-off-by: assafad <aadmi@redhat.com>