### PR TITLE
Update deprecated runbook api name

### DIFF
--- a/alerts/openshift-virtualization-operator/KubeVirtDeprecatedAPIRequested.md
+++ b/alerts/openshift-virtualization-operator/KubeVirtDeprecatedAPIRequested.md
@@ -1,4 +1,4 @@
-# KubeVirtDeprecatedAPIsRequested
+# KubeVirtDeprecatedAPIRequested
 
 ## Meaning
 


### PR DESCRIPTION
Updating runbook name to align with [kubevirt runbook PR](https://github.com/kubevirt/kubevirt/pull/9883).