### PR TITLE
Fix KubemacpoolDown runbook

### DIFF
--- a/alerts/openshift-virtualization-operator/KubemacpoolDown.md
+++ b/alerts/openshift-virtualization-operator/KubemacpoolDown.md
@@ -1,4 +1,4 @@
-# KubeMacPoolDown
+# KubemacpoolDown
 
 ## Meaning
 


### PR DESCRIPTION
Currently, [KubemacpoolDown alert](https://github.com/kubevirt/cluster-network-addons-operator/blob/main/data/monitoring/prom-rule.yaml#L57) has a runbook with the name `KubeMacPoolDown`. This PR fixes this.