### PR TITLE
Update NodeClockNotSynchronising.md

### DIFF
--- a/alerts/cluster-monitoring-operator/NodeClockNotSynchronising.md
+++ b/alerts/cluster-monitoring-operator/NodeClockNotSynchronising.md
@@ -21,6 +21,7 @@ check the `chronyd` service:
 
 ```shell
 oc -n default debug node/<affected_node_name>
+chroot /host
 systemctl status chronyd
 ```
 


### PR DESCRIPTION
Small update on the runbook, without chroot /host to check the chronyd status it will end in:

Running in chroot, ignoring request: start