### PR TITLE
Add runbook help for next set of alerts

### DIFF
--- a/alerts/openshift-container-storage-operator/CephMdsMissingReplicas.md
+++ b/alerts/openshift-container-storage-operator/CephMdsMissingReplicas.md
@@ -1,0 +1,24 @@
+# CephMdsMissingReplicas
+
+## Meaning
+
+Minimum required replicas for the storage metadata service (MDS) are not available.
+This might affect the working of storage cluster.
+
+## Impact
+
+MDS is responsible for file metadata. Degradation of the MDS service can affect the
+working of the storage cluster (related to cephfs storage class) and should be fixed
+as soon as possible.
+
+## Diagnosis
+
+Make sure we have enough RAM provisioned for MDS Cache. Default is 4GB, but recomended
+is minimum 8GB.
+
+## Mitigation
+
+It is highly recomended to distribute MDS daemons across at least two nodes in
+the cluster. Otherwise, a hardware failure on a single node may result in the
+file system becoming unavailable.
+

--- a/alerts/openshift-container-storage-operator/CephMgrIsAbsent.md
+++ b/alerts/openshift-container-storage-operator/CephMgrIsAbsent.md
@@ -1,0 +1,45 @@
+# CephMgrIsAbsent
+
+## Meaning
+
+Ceph Manager cannot be found or accessed from Prometheus target discovery.
+
+## Impact
+
+Storage metrics collector won't be available and users won't be able to see
+the storage metrics anymore. Not having a Ceph manager running impacts the
+monitoring of the cluster, PVC creation and deletion requests and should be
+resolved as soon as possible. Impact is critical here.
+
+## Diagnosis
+
+### Check if it is a network issue
+Check the [network connectivity](helpers/networkConnectivity.md).
+We cannot do much about the possible causes of network issues
+e.g. misconfigured AWS security group.
+Therefore, if it is a network issue, escalate to the ODF team by following
+the steps [here](helpers/sre-to-engineering-escalation.md#procedure).
+
+## Mitigation
+
+Verify the rook-ceph-mgr pod is failing and restart if necessary.
+If the ceph mgr pod restart fails, use general basic pod troubleshooting to resolve.
+
+Verify the ceph mgr pod is failing:
+
+    oc get pods -n openshift-storage | grep mgr
+
+Describe the ceph mgr pod for more detail:
+
+    oc describe -n openshift-storage pods/<rook-ceph-mgr pod name from previous step>
+
+Analyze errors (i.e. resource issues?)
+
+Try deleting the pod and watch for a successful restart:
+
+    oc get pods -n openshift-storage | grep mgr
+
+If above fails, follow general pod troubleshooting procedures.
+
+[pod debug](helpers/podDebug.md) [gather_logs](helpers/gatherLogs.md)
+

--- a/alerts/openshift-container-storage-operator/CephMgrIsMissingReplicas.md
+++ b/alerts/openshift-container-storage-operator/CephMgrIsMissingReplicas.md
@@ -1,0 +1,26 @@
+# CephMgrIsMissingReplicas
+
+## Meaning
+
+Ceph Manager is missing replicas. That means Storage metrics collector
+service doesn't have required no of replicas.
+
+## Impact
+
+This impacts the health status reporting and will cause some of the information
+reported by `ceph status` to be missing or stale. In addition, the ceph manager
+is responsible for a Manager framework aimed at expanding the Ceph existing capabilities.
+
+## Diagnosis
+
+To resolve this alert, you will need to determine the cause of the disappearance
+of the Ceph Manager through the logs and restart if necessary.
+
+## Mitigation
+
+Check the manager pod's logs. Verify the rook-ceph-mgr pod is failing and restart
+if necessary. If the ceph mgr pod restart fails, use general basic pod troubleshooting
+to resolve.
+
+[pod debug](helpers/podDebug.md) [gather_logs](helpers/gatherLogs.md)
+

--- a/alerts/openshift-container-storage-operator/CephMonHighNumberOfLeaderChanges.md
+++ b/alerts/openshift-container-storage-operator/CephMonHighNumberOfLeaderChanges.md
@@ -1,0 +1,32 @@
+# CephMonHighNumberOfLeaderChanges
+
+## Meaning
+
+In a Ceph cluster there is a redundant set of monitors that store critical
+information about the storage cluster. Monitors synchronize periodically to
+obtain information about the storage cluster. The first monitor to get the
+most updated information become leader and other monitors will start their
+synchronization process asking the leader.
+
+This alert indicates a high frequent Ceph Monitor leader change per minute.
+
+## Impact
+
+An unusual change of leader is usually produced by problems in network
+connection, or another kind of problem in one or more monitor pods.
+This situation can affect negatively to the storage cluster performance.
+
+## Diagnosis
+
+The alert should indicate the monitor pod with the problem:
+
+    Ceph Monitor <rook-ceph-mon-X... pod> on host <hostX> has seen <X> leader
+    changes per minute recently.
+
+Check the affected monitor's logs. More information on the cause can be seen
+from these logs.
+
+## Mitigation
+
+[pod debug](helpers/podDebug.md) [gather_logs](helpers/gatherLogs.md)
+

--- a/alerts/openshift-container-storage-operator/CephMonQuorumAtRisk.md
+++ b/alerts/openshift-container-storage-operator/CephMonQuorumAtRisk.md
@@ -1,0 +1,25 @@
+# CephMonQuorumAtRisk
+
+## Meaning
+
+Storage cluster quorum is low.
+Multiple mons work together to provide redundancy by each keeping a copy
+of the metadata. Cluster is deployed with 3 mons, and require 2 or more mons
+to be up and running for quorum and for the storage operations to run.
+
+## Impact
+
+If quorum is lost, access to data is at risk.
+
+## Diagnosis
+
+Run following command for each Monitor in the cluster.
+`ceph tell mon.ID mon_status`
+
+For more on this command’s output, see [Understanding mon_status](https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-mon/#rados-troubleshoting-troubleshooting-mon-understanding-mon-status).
+
+## Mitigation
+
+[Restore Ceph Mon Quorum Lost](https://access.redhat.com/solutions/5898541)
+[Troubleshooting Monitor](https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-mon/)
+

--- a/alerts/openshift-container-storage-operator/CephMonQuorumLost.md
+++ b/alerts/openshift-container-storage-operator/CephMonQuorumLost.md
@@ -1,0 +1,29 @@
+# CephMonQuorumLost
+
+## Meaning
+
+The number of monitors in the storage cluster are not enough.
+Multiple mons work together to provide redundancy by each keeping a copy
+of the metadata. Cluster is deployed with 3 mons, and require 2 or more mons
+to be up and running for quorum and for the storage operations to run.
+
+This alert indicates that there is only 1 monitor pod running or even none.
+
+## Impact
+
+If quorum is lost and it is beyond recovery now. Any data lose is permanent
+at this point.
+
+## Diagnosis
+
+Set logging to files true,
+`# ceph config set global log_to_file true`
+`# ceph config set global mon_cluster_log_to_file true`
+Then check the corresponding Ceph Monitor logs in /var/log/ceph/<cluster-id> location
+
+## Mitigation
+
+[Restore Ceph Mon Quorum Lost](https://access.redhat.com/solutions/5898541)
+[Troubleshooting Monitor](https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-mon/)
+
+

--- a/alerts/openshift-container-storage-operator/CephNodeDown.md
+++ b/alerts/openshift-container-storage-operator/CephNodeDown.md
@@ -1,0 +1,63 @@
+# CephNodeDown
+
+## Meaning
+
+This alert indicates that one of the Ceph storage node went down.
+
+## Impact
+
+A node running Ceph pods is down. While storage operations will continue to
+function as Ceph is designed to deal with a node failure, it is recommended
+to resolve the issue to minimise risk of another node going down and affecting
+storage functions.
+
+## Diagnosis
+
+The alert message will clearly indicate which node is down
+
+    Storage node <nod-name> went down. Please check the node immediately.
+
+## Mitigation
+
+Document the current OCS pods (running and failing):
+
+    oc -n openshift-storage get pods
+
+The OCS resource requirements must be met in order for the osd pods to be
+scheduled on the new node. This may take a few minutes as the ceph cluster
+recovers data for the failing but now recovering osd.
+
+To watch this recovery in action ensure the osd pods were actually placed on the
+new worker node.
+
+Check if the previous failing osd pods are now running:
+
+    oc -n openshift-storage get pods
+
+If the previously failing osd pods have not been scheduled, use describe and
+check events for reasons the pods were not rescheduled.
+
+Describe events for failing osd pod:
+
+    oc -n openshift-storage get pods | grep osd
+
+Find a failing osd pod(s):
+
+    oc -n openshift-storage describe pods/<osd podname from previous step>
+
+In the event section look for failure reasons, such as resources not being met.
+
+In addition, you may use the rook-ceph-toolbox to watch the recovery. This step
+is optional but can be helpful for large Ceph clusters.
+
+**Determine failed OCS Node** [determine_failed_ocs_node](helpers/determineFailedOcsNode.md)
+
+[access toolbox](helpers/accessToolbox.md)
+
+From the rsh command prompt, run the following and watch for "recovery" under
+the io section:
+
+    ceph status
+
+[gather logs](helpers/gatherLogs.md)
+

--- a/alerts/openshift-container-storage-operator/CephOSDCriticallyFull.md
+++ b/alerts/openshift-container-storage-operator/CephOSDCriticallyFull.md
@@ -1,0 +1,43 @@
+# CephOSDCriticallyFull
+
+## Meaning
+
+Utilization of back-end storage device (OSD) has crossed 80%.
+Immediately free up some space or expand the storage cluster or contact support.
+
+## Impact
+
+One of the OSD Storage size has crossed 80% of the total capacity. Expand the
+cluster immediately.
+
+## Diagnosis
+
+Alert message will have enough information about the underlying failure.
+It should show the name of 'ceph-daemon', 'device-class' and the 'host-name'.
+
+A sample alert message is provided below,
+
+    Utilization of storage device <ceph-daemon-name> of device_class type
+<device-class-name> has crossed 80% on host <host-name>. Immediately free up
+some space or add capacity of type <device-class>.
+
+## Mitigation
+
+### Delete data
+
+The customer may delete data and the cluster will resolve the alert through self
+healing processes.
+
+### Expand the storage capacity
+
+Customer may assess their ability to expand. Here are some points,
+
+**Current Storage Size < 1TB**:  
+The customer may increase capacity via the addon and the cluster will resolve
+the alert through self healing processes.
+
+**Current Size itself is 1TB**:
+Please contact your dedicated customer care support.
+
+[gather_logs](helpers/gatherLogs.md)
+

--- a/alerts/openshift-container-storage-operator/ClusterObjectStoreState.md
+++ b/alerts/openshift-container-storage-operator/ClusterObjectStoreState.md
@@ -1,0 +1,24 @@
+# ClusterObjectStoreState
+
+## Meaning
+
+RGW endpoint of the Ceph object store is in a failure state,
+OR
+One or more Rook Ceph RGW deployments have fewer ready replicas than required
+for more than 15s.
+
+## Impact
+
+Cluster Object Store is in unhealthy state
+OR
+Number of ready replicas for Rook Ceph RGW deployments is less than the desired replicas.
+
+## Diagnosis
+
+### TODO
+
+## Mitigation
+
+Please check the health of the Ceph cluster and the deployments and find the
+root cause of the issue.
+

--- a/alerts/openshift-container-storage-operator/ObcQuotaBytesExhausedAlert.md
+++ b/alerts/openshift-container-storage-operator/ObcQuotaBytesExhausedAlert.md
@@ -1,0 +1,23 @@
+# ObcQuotaBytesExhausedAlert
+
+## Meaning
+
+This is the next stage once we have reached [ObcQuotaObjectsAlert](ObcQuotaObjectsAlert.md).
+ObjectBucketClaim has crossed the limit set by the quota(bytes) and will be
+read-only now. Increase the quota in the OBC custom resource immediately.
+
+## Impact
+
+OBC has exhausted and reached it's limit.
+
+## Diagnosis
+
+Alert message will clearly indicate which OBC has reached the quota bytes limit.
+Look at the deployments attached to the OBC and see what all apps are
+using/filling-up the OBC.
+For quota help please visit: https://access.redhat.com/articles/6541861
+
+## Mitigation
+
+Need to increase the quota limit immediately for the ObjectBucketClaim custom resource.
+

--- a/alerts/openshift-container-storage-operator/ObcQuotaObjectsAlert.md
+++ b/alerts/openshift-container-storage-operator/ObcQuotaObjectsAlert.md
@@ -1,0 +1,23 @@
+# ObcQuotaObjectsAlert
+
+## Meaning
+
+An ObjectBucketClaim object has crossed 80% of the size limit set by the quota(objects)
+and will become read-only on reaching the quota limit.
+
+## Impact
+
+OBC has reached 80% of it's limit and soon will get exhausted once reaching
+the quota limit.
+
+## Diagnosis
+
+Alert message will clearly indicate which OBC is being filled up fast.
+Look at the deployments attached to the OBC and
+see what all apps are using/filling-up the OBC.
+For quota help please visit: https://access.redhat.com/articles/6541861
+
+## Mitigation
+
+Increase the quota limit for the ObjectBucketClaim custom resource.
+

--- a/alerts/openshift-container-storage-operator/ObcQuotaObjectsExhausedAlert.md
+++ b/alerts/openshift-container-storage-operator/ObcQuotaObjectsExhausedAlert.md
@@ -1,0 +1,22 @@
+# ObcQuotaObjectsExhausedAlert
+
+## Meaning
+
+ObjectBucketClaim has crossed the limit set by the quota(objects) and
+will be read-only now.
+
+## Impact
+
+Application won't be able to do any transaction through the OBC and will be stalled.
+
+## Diagnosis
+
+Alert message will indicate which OBC has reached the object quota limit.
+Look at the deployments attached to the OBC and
+see what all apps are using/filling-up the OBC.
+For quota help please visit: https://access.redhat.com/articles/6541861
+
+## Mitigation
+
+Immediately increase the quota for the OBC, specified in the alert details.
+

--- a/alerts/openshift-container-storage-operator/helpers/accessToolbox.md
+++ b/alerts/openshift-container-storage-operator/helpers/accessToolbox.md
@@ -1,0 +1,6 @@
+# Access the Toolbox
+
+Run the following to rsh to the toolbox pod:
+
+    TOOLS_POD=$(oc get pods -n openshift-storage -l app=rook-ceph-tools -o name)
+    oc rsh -n openshift-storage $TOOLS_POD

--- a/alerts/openshift-container-storage-operator/helpers/sre-to-engineering-escalation.md
+++ b/alerts/openshift-container-storage-operator/helpers/sre-to-engineering-escalation.md
@@ -1,0 +1,141 @@
+# SRE-to-ODF-Engineering escalation path
+
+## Purpose
+
+This SOP describes how the SRE Team will escalate issues to the
+ODF Engineering Team in case of incidents which would require help
+from ODF engineering to resolve them.
+
+## Scope
+
+The scope of this escalation path is to cover the incidents which have
+unavailability/data loss associated with the customer and none of the
+existing SOPs help to resolve the respective incident at the same time.
+
+## Prerequisites
+
+* `MTSRE` Role permissions over OCM.
+
+## Responsibilities
+
+* SRE to only escalate the issue to engineering on an urgent basis when the
+incident is associated with unavailability or data loss for the customer.
+* ocm-cli version 0.1.63
+
+## Procedure
+
+### Determine whether the incident leads to unavailability / data loss for the customer
+
+The best way to determine this is to see if the corresponding provider cluster
+has any storageconsumers or not.
+
+* Determine the cluster ID of the Provider cluster associated with the customer,
+in case it's not directly available from PagerDuty incident: Happens when the
+incident's source is an ocs-consumer.
+
+* Backplane access into the provider cluster (Checkout [References](#references)
+for the SOP to do so).
+
+* See if there are any storageconsumers or not.
+
+    oc get storageconsumers.ocs.openshift.io -n openshift-storage
+
+If there are no storageconsumers, then wait until the next set of ODF's working
+hours to escalate the issue to engineering.
+
+### Escalation path when the incident urgently requires help from ODF Engineering
+
+* Follow the steps in [link](<https://source.redhat.com/groups/public/openshiftplatformsre/wiki/how_to_sre_escalate_towards_engineering>),
+starting with submitting the Google Form,
+to get help from the ODF Engineering Team.
+
+### If above steps do not work
+
+Follow the manual steps to escalate to ODF Engineering Team
+
+* Fetch certain details of the impacted cluster:
+  * Cluster Details:
+
+    ocm describe cluster <internal/external-id-of-cluster>
+
+    For example
+
+    ```bash
+    ❯ ocm describe cluster 1s0q9mp65e2f370q9s7ip75g6sj0sifg
+
+    ID:      1s0q9mp65e2f370q9s7ip75g6sj0sifg
+    External ID:    7ca71103-f0d8-4e66-a586-35332eaa4b10
+    Name:      e2e-ci-prov
+    State:      ready
+    API URL:    https://<management-domain-address>:6443
+    API Listening:    external
+    Console URL:    https://<url-address-through-which-we-access-cluster-console-ui>
+    Masters:    3
+    Infra:      2
+    Computes:    3
+    Product:    osd
+    Provider:    aws
+    Version:    4.10.11
+    Region:      us-west-2
+    Multi-az:    false
+    CCS:      true
+    Subnet IDs:    [subnet-06a34a7bb480707bf subnet-07b3053eb531c5e70]
+    PrivateLink:    false
+    STS:      false
+    Existing VPC:    true
+    Channel Group:    stable
+    Cluster Admin:    true
+    Organization:    Red Hat-Storage-OCS
+    Creator:    <name>-storage-ocs
+    Email:      <name>@domain.com
+    AccountNumber: <acc-number>
+    Created:    2022-05-05T15:53:01Z
+    Expiration:    2022-06-16T14:09:19Z
+    Shard:      https://domain-name.openshiftapps.com:6443
+    ```
+
+* Open a Jira ticket in the [RHOSDFP Jira board](<https://issues.redhat.com/projects/RHOSDFP>)
+with the following details:
+
+    ```bash
+    Basic Details:
+
+    Addon name:
+    Addon version: <can be gotten via
+                   `oc get csvs -n <addon-namespace>` on the affected cluster>
+    OCP version:
+    Business Impact:
+    Description:
+
+    Cluster and Customer Details:
+        <output of the following command> `ocm describe cluster <internal-id>`
+
+    Pagerduty Incident: <PD URL pointing to the incident>
+    ```
+
+    Additional Operators which came with the addon (including the core addon's
+    operator): \<output of the following command from inside the affected cluster>
+    `oc get csvs -n openshift-storage`
+
+    (Example ticket mentioned in the [References](#references))
+
+* Open a google chat thread in [ODF Managed Services Escalation](https://mail.google.com/chat/u/0/?zx=545uzcc7jlkp#chat/space/AAAAOdTnXXo)
+  * @hey odf-cae-team I need engineering assistance with \<RHOSDFP ticket you created>
+  * Then in the next message in the thread provide a short description of the issue.
+* One of the Engineering escalation contacts is expected to ack the escalation
+coming from SRE in under 15 minutes and involve the right set of engineering
+team on the issue.
+* Get in touch with the associated person of ODF Engineering and get on a bridge
+call with them if need be to resolve the issue.
+* If there is no acknowledgement by the engineering escalation contacts, a call
+should be made to the engineering escalation contact as per [this table](<https://docs.google.com/document/d/1RKvxXnxoIaIPW-tbONnZ1t9Pmec5TH2qYgDzAKSKtO4/edit#bookmark=kix.x1bsgr3rpjx6>).
+
+## References
+
+* [OCM CLI Version 0.1.63](https://github.com/openshift-online/ocm-cli/releases/tag/v0.1.63)
+* [RHSTOR Jira board](https://issues.redhat.com/projects/RHSTOR)
+* [ODF Managed Services Escalation](https://mail.google.com/chat/u/0/?zx=545uzcc7jlkp#chat/space/AAAAOdTnXXo)
+* [Example of RHSTOR ticket](https://issues.redhat.com/projects/RHSTOR/issues/RHSTOR-3329)
+* [Steps to backplane access into a cluster](https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/MT-SRE/sops/addon-enable-backplane.md)
+* [Interim SRE-to-ODF-Engineering escalation path](https://docs.google.com/document/d/1RKvxXnxoIaIPW-tbONnZ1t9Pmec5TH2qYgDzAKSKtO4/edit)
+* [RHSTOR ticket tracking the RFE to allow fetching the Provider Cluster ID from any of its associated consumers](https://issues.redhat.com/browse/RHSTOR-3381)


### PR DESCRIPTION
Adding runbook help for the following alerts,

CephMgrIsAbsent
CephMgrIsMissingReplicas
CephMdsMissingReplicas
CephMonQuorumAtRisk
CephMonQuorumLost
CephMonHighNumberOfLeaderChanges
CephNodeDown
CephOSDCriticallyFull

ObcQuotaObjectsAlert
ObcQuotaBytesExhausedAlert
ObcQuotaObjectsExhausedAlert
ClusterObjectStoreState