### PR TITLE
Fix CephClusterReadOnly alert title

### DIFF
--- a/alerts/openshift-container-storage-operator/CephClusterReadOnly.md
+++ b/alerts/openshift-container-storage-operator/CephClusterReadOnly.md
@@ -1,4 +1,4 @@
-# CephClusterCriticallyFull
+# CephClusterReadOnly
 
 ## Meaning
 


### PR DESCRIPTION
The title of the document was wrong.

this alert is part of the work for RHSTOR-4979.
