### PR TITLE
[CNV] HCOInstallationIncomplete runbook fix

### DIFF
--- a/alerts/openshift-virtualization-operator/HCOInstallationIncomplete.md
+++ b/alerts/openshift-virtualization-operator/HCOInstallationIncomplete.md
@@ -22,11 +22,11 @@ default values:
 
   ```bash
   $ cat <<EOF | oc apply -f -
-  apiVersion: operators.coreos.com/v1
-  kind: OperatorGroup
+  apiVersion: hco.kubevirt.io/v1beta1
+  kind: HyperConverged
   metadata:
-    name: hco-operatorgroup
-    namespace: kubevirt-hyperconverged
+    name: kubevirt-hyperconverged
+    namespace: openshift-cnv
   spec: {}
   EOF
   ```


### PR DESCRIPTION
Fixing an incorrect example in the HCOInstallationIncomplete runbook.

This issue was discovered in a discussion on a kubevirt/monitoring PR: https://github.com/kubevirt/monitoring/pull/240/files

I am also fixing this in the downstream docs here: https://github.com/openshift/openshift-docs/pull/75888

@machadovilaca @tiraboschi Please review this if possible and feel free to tag anyone else who should review it. Thanks!