### PR TITLE
Removing PV usage percentage numbers from runbooks doc text

### DIFF
--- a/alerts/openshift-container-storage-operator/PersistentVolumeUsageCritical.md
+++ b/alerts/openshift-container-storage-operator/PersistentVolumeUsageCritical.md
@@ -4,7 +4,8 @@
 
 A PVC is nearing its full capacity and may lead to data loss if not attended to
 timely. The alert will be fired when Persistent Volume Claim usage has exceeded
-more than 85% of its capacity.
+the final threshold limit of its capacity.
+Please see the alert documentation text for an exact threshold limit.
 
 ## Impact
 

--- a/alerts/openshift-container-storage-operator/PersistentVolumeUsageNearFull.md
+++ b/alerts/openshift-container-storage-operator/PersistentVolumeUsageNearFull.md
@@ -2,8 +2,9 @@
 
 ## Meaning
 
-Persistent Volume Claim (PVC) usage has exceeded 75% of its capacity,
+Persistent Volume Claim (PVC) usage is alarmingly very high,
 indicating an imminent risk of reaching full capacity.
+Please see the alert documentation text for an exact threshold limit.
 
 ## Impact
 
@@ -16,8 +17,9 @@ leading to data loss if not addressed promptly.
 ## Diagnosis
 
 The alert triggers when a Persistent Volume Claim (PVC) approaches or surpasses
-75% of its capacity. It indicates the need to expand the PVC size to accommodate
-more data or to remove unnecessary data to free up space.
+very high capacity limit. It indicates the need to expand the PVC size to
+accommodate more data or to remove unnecessary data to free up space.
+Please see the alert documentation text for an exact threshold limit.
 
 **Prerequisites:** [Prerequisites](helpers/diagnosis.md)
 


### PR DESCRIPTION
As we are changing the alert percentages from newer ODF version onwards, making the runbooks documentation texts general, thus making runbooks not dependant on ODF versions.