### PR TITLE
Modify MDS CPU runbook to scale mds pods.

### DIFF
--- a/alerts/openshift-container-storage-operator/CephMdsCpuUsageHigh.md
+++ b/alerts/openshift-container-storage-operator/CephMdsCpuUsageHigh.md
@@ -13,7 +13,7 @@ MDS is by default is allocated 2 or 3 CPUS.
 It is okay as long as metadata operations are not too many.
 When the metadata operation load increases enough to trigger this alert,
 it means the default CPU allocation is unable to cope with load and we need to
-increase the CPU allocation.
+increase the CPU allocation or run multiple active metadata servers.
 
 ## Diagnosis
 
@@ -25,8 +25,8 @@ If this is the case take the steps mentioned in mitigation.
 
 ## Mitigation
 
-We need to increase the allocated CPU. The below command describes
-how to set the number of allocated CPU for MDS server.
+We need to either increase the allocated CPU or run multiple active MDS. The
+below command describes how to set the number of allocated CPU for MDS server.
 
 ```bash
 oc patch -n openshift-storage storagecluster ocs-storagecluster \
@@ -34,3 +34,17 @@ oc patch -n openshift-storage storagecluster ocs-storagecluster \
     --patch '{"spec": {"resources": {"mds": {"limits": {"cpu": "8"},
     "requests": {"cpu": "8"}}}}}'
 ```
+
+In order to run multiple active MDS servers, use below command
+
+```bash
+oc patch -n openshift-storage cephfilesystem ocs-storagecluster-cephfilesystem\
+    --type merge \
+    --patch '{"spec": {"metadataServer": {"activeCount": 2}}}'
+
+Make sure we have enough CPU provisioned for MDS depending on the load.
+```
+
+Always increase the `activeCount` by 1. The scaling of activeCount works only
+if you have more than one PV. If there is only one PV that is causing CPU load,
+look at increasing the cpu resource as described above.


### PR DESCRIPTION
This was removed because the feature was not QA'd, now that it is, adding back the runback to horizontally scale MDS.