### PR TITLE
OCPBUGS-36495: Update alert desc in ClusterMonitoringOperatorDeprecatedConfig

### DIFF
--- a/alerts/cluster-monitoring-operator/ClusterMonitoringOperatorDeprecatedConfig.md
+++ b/alerts/cluster-monitoring-operator/ClusterMonitoringOperatorDeprecatedConfig.md
@@ -20,8 +20,7 @@ the
 
   `The configuration field k8sPrometheusAdapter in
   openshift-monitoring/cluster-monitoring-config was deprecated in 4.16 and has
-  no effect, you can migrate
-  to metricsServer config instead`.
+  no effect`.
 
   __Summary__
 


### PR DESCRIPTION
Related -to https://github.com/openshift/cluster-monitoring-operator/pull/2410
Since `ClusterMonitoringOperatorDeprecatedConfig` would be common for all deprecated configs it would be hard to tell in alert description whether to remove or migrate. I think it would be best to navigate to runbook