### PR TITLE
Update openshift-virtualization-operator runbook

### DIFF
--- a/alerts/openshift-virtualization-operator/CDIStorageProfilesIncomplete.md
+++ b/alerts/openshift-virtualization-operator/CDIStorageProfilesIncomplete.md
@@ -18,7 +18,7 @@ The CDI cannot create a VM disk on the PVC.
 - Identify the incomplete storage profile:
 
   ```bash
-  $ oc get storageprofile <storage_class>
+  $ oc get storageprofile -o json | jq '.items[] | select(.status.claimPropertySets == null or .status.claimPropertySets == []) | .metadata.name'
   ```
 
 ## Mitigation

--- a/alerts/openshift-virtualization-operator/KubeVirtVMIExcessiveMigrations.md
+++ b/alerts/openshift-virtualization-operator/KubeVirtVMIExcessiveMigrations.md
@@ -19,7 +19,7 @@ performance because memory page faults occur during the transition.
 1. Verify that the worker node has sufficient resources:
 
    ```bash
-   $ oc get nodes -l node-role.kubernetes.io/worker= -o json | jq .items[].status.allocatable
+   $ oc get nodes -l node-role.kubernetes.io/worker= -o json | jq '.items[].status.allocatable'
    ```
 
    Example output:
@@ -42,7 +42,7 @@ performance because memory page faults occur during the transition.
 2. Check the status of the worker node:
 
    ```bash
-   $ oc get nodes -l node-role.kubernetes.io/worker= -o json | jq .items[].status.conditions
+   $ oc get nodes -l node-role.kubernetes.io/worker= -o json | jq '.items[].status.conditions'
    ```
 
    Example output:

--- a/alerts/openshift-virtualization-operator/LowReadyVirtControllersCount.md
+++ b/alerts/openshift-virtualization-operator/LowReadyVirtControllersCount.md
@@ -21,7 +21,7 @@ launching a new VMI or shutting down an existing VMI.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Verify a `virt-controller` device is available:

--- a/alerts/openshift-virtualization-operator/LowReadyVirtControllersCount.md
+++ b/alerts/openshift-virtualization-operator/LowReadyVirtControllersCount.md
@@ -21,7 +21,7 @@ launching a new VMI or shutting down an existing VMI.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Verify a `virt-controller` device is available:

--- a/alerts/openshift-virtualization-operator/LowReadyVirtOperatorsCount.md
+++ b/alerts/openshift-virtualization-operator/LowReadyVirtOperatorsCount.md
@@ -32,7 +32,7 @@ affect VM workloads.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Obtain the name of the `virt-operator` deployment:

--- a/alerts/openshift-virtualization-operator/LowReadyVirtOperatorsCount.md
+++ b/alerts/openshift-virtualization-operator/LowReadyVirtOperatorsCount.md
@@ -32,7 +32,7 @@ affect VM workloads.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Obtain the name of the `virt-operator` deployment:

--- a/alerts/openshift-virtualization-operator/LowVirtAPICount.md
+++ b/alerts/openshift-virtualization-operator/LowVirtAPICount.md
@@ -15,7 +15,7 @@ becomes a single point of failure.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Check the number of available `virt-api` pods:

--- a/alerts/openshift-virtualization-operator/LowVirtAPICount.md
+++ b/alerts/openshift-virtualization-operator/LowVirtAPICount.md
@@ -15,7 +15,7 @@ becomes a single point of failure.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Check the number of available `virt-api` pods:

--- a/alerts/openshift-virtualization-operator/LowVirtControllersCount.md
+++ b/alerts/openshift-virtualization-operator/LowVirtControllersCount.md
@@ -25,7 +25,7 @@ OpenShift Virtualization might become completely unresponsive.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Verify that running `virt-controller` pods are available:
@@ -37,14 +37,14 @@ OpenShift Virtualization might become completely unresponsive.
 3. Check the `virt-launcher` logs for error messages:
 
    ```bash
-   $ oc -n $NAMESPACE logs <virt-launcher>
+   $ oc -n $NAMESPACE logs <virt-controller>
    ```
 
 4. Obtain the details of the `virt-launcher` pod to check for status conditions
 such as unexpected termination or a `NotReady` state.
 
    ```bash
-   $ oc -n $NAMESPACE describe pod/<virt-launcher>
+   $ oc -n $NAMESPACE describe pod/<virt-controller>
    ```
 
 ## Mitigation

--- a/alerts/openshift-virtualization-operator/LowVirtControllersCount.md
+++ b/alerts/openshift-virtualization-operator/LowVirtControllersCount.md
@@ -25,7 +25,7 @@ OpenShift Virtualization might become completely unresponsive.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Verify that running `virt-controller` pods are available:
@@ -34,17 +34,17 @@ OpenShift Virtualization might become completely unresponsive.
    $ oc -n $NAMESPACE get pods -l kubevirt.io=virt-controller
    ```
 
-3. Check the `virt-launcher` logs for error messages:
+3. Check the `virt-controller` logs for error messages:
 
    ```bash
-   $ oc -n $NAMESPACE logs <virt-controller>
+   $ oc -n $NAMESPACE logs -l kubevirt.io=virt-controller
    ```
 
-4. Obtain the details of the `virt-launcher` pod to check for status conditions
+4. Obtain the details of the `virt-controller` pod to check for status conditions
 such as unexpected termination or a `NotReady` state.
 
    ```bash
-   $ oc -n $NAMESPACE describe pod/<virt-controller>
+   $ oc -n $NAMESPACE describe pods -l kubevirt.io=virt-controller
    ```
 
 ## Mitigation

--- a/alerts/openshift-virtualization-operator/LowVirtOperatorCount.md
+++ b/alerts/openshift-virtualization-operator/LowVirtOperatorCount.md
@@ -29,7 +29,7 @@ VM workloads.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Check the states of the `virt-operator` pods:

--- a/alerts/openshift-virtualization-operator/LowVirtOperatorCount.md
+++ b/alerts/openshift-virtualization-operator/LowVirtOperatorCount.md
@@ -29,7 +29,7 @@ VM workloads.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Check the states of the `virt-operator` pods:

--- a/alerts/openshift-virtualization-operator/NetworkAddonsConfigNotReady.md
+++ b/alerts/openshift-virtualization-operator/NetworkAddonsConfigNotReady.md
@@ -18,7 +18,7 @@ Network functionality is affected.
 deployment or daemon set that is not ready:
 
    ```bash
-   $ oc get networkaddonsconfig -o custom-columns="":.status.conditions[*].message
+   $ oc get networkaddonsconfig -o custom-columns=':.status.conditions[*].message'
    ```
 
    Example output:
@@ -30,7 +30,7 @@ deployment or daemon set that is not ready:
 2. Check the component's pod for errors:
 
    ```bash
-   $ oc -n cluster-network-addons get daemonset <pod> -o yaml
+   $ oc -n cluster-network-addons get daemonset <demonset> -o yaml
    ```
 
 3. Check the component's logs:
@@ -42,7 +42,7 @@ deployment or daemon set that is not ready:
 4. Check the component's details for error conditions:
 
    ```bash
-   $ oc -n cluster-network-addons describe <pod>
+   $ oc -n cluster-network-addons describe pod <pod>
    ```
 
 ## Mitigation

--- a/alerts/openshift-virtualization-operator/NetworkAddonsConfigNotReady.md
+++ b/alerts/openshift-virtualization-operator/NetworkAddonsConfigNotReady.md
@@ -18,31 +18,31 @@ Network functionality is affected.
 deployment or daemon set that is not ready:
 
    ```bash
-   $ oc get networkaddonsconfig -o custom-columns=':.status.conditions[*].message'
+   $ oc get networkaddonsconfig -o custom-columns=':.status.conditions[*].message' | tr -d '\n'
    ```
 
    Example output:
 
    ```text
-   DaemonSet "cluster-network-addons/macvtap-cni" update is being processed...
+   DaemonSet "openshift-cnv/macvtap-cni" update is being processed...
    ```
 
 2. Check the component's pod for errors:
 
    ```bash
-   $ oc -n cluster-network-addons get daemonset <demonset> -o yaml
+   $ oc -n openshift-cnv get daemonset <daemonset> -o yaml
    ```
 
 3. Check the component's logs:
 
    ```bash
-   $ oc -n cluster-network-addons logs <pod>
+   $ oc -n openshift-cnv logs <pod>
    ```
 
 4. Check the component's details for error conditions:
 
    ```bash
-   $ oc -n cluster-network-addons describe pod <pod>
+   $ oc -n openshift-cnv describe pod <pod>
    ```
 
 ## Mitigation

--- a/alerts/openshift-virtualization-operator/NoLeadingVirtOperator.md
+++ b/alerts/openshift-virtualization-operator/NoLeadingVirtOperator.md
@@ -31,7 +31,7 @@ rotation, upgrade, and reconciliation of controllers, might not be available.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Obtain the status of the `virt-operator` pods:
@@ -43,7 +43,7 @@ rotation, upgrade, and reconciliation of controllers, might not be available.
 3. Check the `virt-operator` pod logs to determine the leader status:
 
    ```bash
-   $ oc -n $NAMESPACE logs <virt-operator> | grep lead
+   $ oc -n $NAMESPACE logs -l kubevirt.io=virt-operator | grep leader
    ```
 
    Leader pod example:

--- a/alerts/openshift-virtualization-operator/NoLeadingVirtOperator.md
+++ b/alerts/openshift-virtualization-operator/NoLeadingVirtOperator.md
@@ -31,7 +31,7 @@ rotation, upgrade, and reconciliation of controllers, might not be available.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Obtain the status of the `virt-operator` pods:
@@ -43,7 +43,7 @@ rotation, upgrade, and reconciliation of controllers, might not be available.
 3. Check the `virt-operator` pod logs to determine the leader status:
 
    ```bash
-   $ oc -n $NAMESPACE logs | grep lead
+   $ oc -n $NAMESPACE logs <virt-operator> | grep lead
    ```
 
    Leader pod example:

--- a/alerts/openshift-virtualization-operator/NoLeadingVirtOperator.md
+++ b/alerts/openshift-virtualization-operator/NoLeadingVirtOperator.md
@@ -43,7 +43,7 @@ rotation, upgrade, and reconciliation of controllers, might not be available.
 3. Check the `virt-operator` pod logs to determine the leader status:
 
    ```bash
-   $ oc -n $NAMESPACE logs -l kubevirt.io=virt-operator | grep leader
+   $ oc -n $NAMESPACE logs -l kubevirt.io=virt-operator | grep lead
    ```
 
    Leader pod example:

--- a/alerts/openshift-virtualization-operator/NoReadyVirtController.md
+++ b/alerts/openshift-virtualization-operator/NoReadyVirtController.md
@@ -21,7 +21,7 @@ launching a new VMI or shutting down an existing VMI.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Verify the number of `virt-controller` devices:

--- a/alerts/openshift-virtualization-operator/NoReadyVirtController.md
+++ b/alerts/openshift-virtualization-operator/NoReadyVirtController.md
@@ -21,7 +21,7 @@ launching a new VMI or shutting down an existing VMI.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Verify the number of `virt-controller` devices:
@@ -46,7 +46,7 @@ conditions such as crashing pods or failure to pull images:
 5. Obtain the details of the `virt-controller` pods:
 
    ```bash
-   $ get pods -n $NAMESPACE | grep virt-controller
+   $ oc get pods -n $NAMESPACE | grep virt-controller
    ```
 
 6. Check the logs of the `virt-controller` pods for error messages:

--- a/alerts/openshift-virtualization-operator/NoReadyVirtOperator.md
+++ b/alerts/openshift-virtualization-operator/NoReadyVirtOperator.md
@@ -31,7 +31,7 @@ custom workloads.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Obtain the name of the `virt-operator` deployment:

--- a/alerts/openshift-virtualization-operator/NoReadyVirtOperator.md
+++ b/alerts/openshift-virtualization-operator/NoReadyVirtOperator.md
@@ -31,7 +31,7 @@ custom workloads.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Obtain the name of the `virt-operator` deployment:

--- a/alerts/openshift-virtualization-operator/OrphanedVirtualMachineInstances.md
+++ b/alerts/openshift-virtualization-operator/OrphanedVirtualMachineInstances.md
@@ -12,24 +12,30 @@ Orphaned VMIs cannot be managed.
 
 ## Diagnosis
 
-1. Check the status of the `virt-handler` pods to view the nodes on which they
+1. Set the `NAMESPACE` environment variable:
+
+   ```bash
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
+   ```
+
+2. Check the status of the `virt-handler` pods to view the nodes on which they
 are running:
 
    ```bash
-   $ oc get pods --all-namespaces -o wide -l kubevirt.io=virt-handler
+   $ oc get pods -n $NAMESPACE -o wide -l kubevirt.io=virt-handler
    ```
 
-2. Check the status of the VMIs to identify VMIs running on nodes that do not
+3. Check the status of the VMIs to identify VMIs running on nodes that do not
 have a running `virt-handler` pod:
 
    ```bash
-   $ oc get vmis --all-namespaces
+   $ oc get vmis -n $NAMESPACE
    ```
 
-3. Check the status of the `virt-handler` daemonset:
+4. Check the status of the `virt-handler` daemonset:
 
    ```bash
-   $ oc get daemonsets --all-namespaces -l kubevirt.io=virt-handler
+   $ oc get daemonsets -n $NAMESPACE -l kubevirt.io=virt-handler
    ```
 
    Example output:
@@ -42,24 +48,24 @@ have a running `virt-handler` pod:
    The daemon set is considered healthy if the `Desired`, `Ready`, and
    `Available` columns contain the same value.
 
-4. If the `virt-handler` daemon set is not healthy, check the `virt-handler`
+5. If the `virt-handler` daemon set is not healthy, check the `virt-handler`
 daemon set for pod deployment issues:
 
    ```bash
-   $ oc get daemonsets --all-namespaces -o json | jq '.items[] | select(.metadata.name=="virt-handler") | .status'
+   $ oc get daemonsets -n $NAMESPACE -o json | jq '.items[] | select(.metadata.name=="virt-handler") | .status'
    ```
 
-5. Check the nodes for issues such as a `NotReady` status:
+6. Check the nodes for issues such as a `NotReady` status:
 
    ```bash
    $ oc get nodes
    ```
 
-6. Check the `spec.workloads` stanza of the `KubeVirt` custom resource (CR) for
+7. Check the `spec.workloads` stanza of the `KubeVirt` custom resource (CR) for
 a workloads placement policy:
 
    ```bash
-   $ oc get kubevirt -n <namespace> -o yaml
+   $ oc get kubevirt -n $NAMESPACE -o yaml
    ```
 
 ## Mitigation

--- a/alerts/openshift-virtualization-operator/OrphanedVirtualMachineInstances.md
+++ b/alerts/openshift-virtualization-operator/OrphanedVirtualMachineInstances.md
@@ -29,7 +29,7 @@ have a running `virt-handler` pod:
 3. Check the status of the `virt-handler` daemon:
 
    ```bash
-   $ oc get daemonset virt-handler --all-namespaces
+   $ oc get daemonsets --all-namespaces | grep virt-handler
    ```
 
    Example output:
@@ -46,7 +46,7 @@ have a running `virt-handler` pod:
 daemon set for pod deployment issues:
 
    ```bash
-   $ oc get daemonset virt-handler --all-namespaces -o yaml | jq .status
+   $ oc get daemonsets --all-namespaces -o json | jq '.items[] | select(.metadata.name=="virt-handler") | .status'
    ```
 
 5. Check the nodes for issues such as a `NotReady` status:
@@ -59,7 +59,7 @@ daemon set for pod deployment issues:
 a workloads placement policy:
 
    ```bash
-   $ oc get kubevirt kubevirt --all-namespaces -o yaml
+   $ oc get kubevirt -n <namespace> <KubeVirt-name> -o yaml
    ```
 
 ## Mitigation

--- a/alerts/openshift-virtualization-operator/OrphanedVirtualMachineInstances.md
+++ b/alerts/openshift-virtualization-operator/OrphanedVirtualMachineInstances.md
@@ -26,10 +26,10 @@ have a running `virt-handler` pod:
    $ oc get vmis --all-namespaces
    ```
 
-3. Check the status of the `virt-handler` daemon:
+3. Check the status of the `virt-handler` daemonset:
 
    ```bash
-   $ oc get daemonsets --all-namespaces | grep virt-handler
+   $ oc get daemonsets --all-namespaces -l kubevirt.io=virt-handler
    ```
 
    Example output:
@@ -59,7 +59,7 @@ daemon set for pod deployment issues:
 a workloads placement policy:
 
    ```bash
-   $ oc get kubevirt -n <namespace> <KubeVirt-name> -o yaml
+   $ oc get kubevirt -n <namespace> -o yaml
    ```
 
 ## Mitigation

--- a/alerts/openshift-virtualization-operator/OutdatedVirtualMachineInstanceWorkloads.md
+++ b/alerts/openshift-virtualization-operator/OutdatedVirtualMachineInstanceWorkloads.md
@@ -16,20 +16,26 @@ Outdated VMIs will not receive the security fixes associated with the
 
 ## Diagnosis
 
-1. Identify the outdated VMIs:
+1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ oc get vmi -l kubevirt.io/outdatedLauncherImage --all-namespaces
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
-2. Check the `KubeVirt` custom resource (CR) to determine whether
+2. Identify the outdated VMIs:
+
+   ```bash
+   $ oc get vmi -l kubevirt.io/outdatedLauncherImage -n $NAMESPACE
+   ```
+
+3. Check the `KubeVirt` custom resource (CR) to determine whether
 `workloadUpdateMethods` is configured in the `workloadUpdateStrategy` stanza:
 
    ```bash
-   $ oc get kubevirt --all-namespaces -o yaml
+   $ oc get kubevirt -n $NAMESPACE -o yaml
    ```
 
-3. Check each outdated VMI to determine whether it is live-migratable:
+4. Check each outdated VMI to determine whether it is live-migratable:
 
    ```bash
    $ oc get vmi <vmi> -o yaml

--- a/alerts/openshift-virtualization-operator/VirtAPIDown.md
+++ b/alerts/openshift-virtualization-operator/VirtAPIDown.md
@@ -13,7 +13,7 @@ OpenShift Virtualization objects cannot send API calls.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Check the status of the `virt-api` pods:

--- a/alerts/openshift-virtualization-operator/VirtAPIDown.md
+++ b/alerts/openshift-virtualization-operator/VirtAPIDown.md
@@ -13,7 +13,7 @@ OpenShift Virtualization objects cannot send API calls.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Check the status of the `virt-api` pods:

--- a/alerts/openshift-virtualization-operator/VirtApiRESTErrorsBurst.md
+++ b/alerts/openshift-virtualization-operator/VirtApiRESTErrorsBurst.md
@@ -19,7 +19,7 @@ affected.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Obtain the list of `virt-api` pods on your deployment:
@@ -37,7 +37,7 @@ affected.
 4. Obtain the details of the `virt-api` pods:
 
    ```bash
-   $ oc describe -n $NAMESPACE <virt-api>
+   $ oc describe pod -n $NAMESPACE <virt-api>
    ```
 
 5. Check if any problems occurred with the nodes. For example, they might be in

--- a/alerts/openshift-virtualization-operator/VirtApiRESTErrorsBurst.md
+++ b/alerts/openshift-virtualization-operator/VirtApiRESTErrorsBurst.md
@@ -19,7 +19,7 @@ affected.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Obtain the list of `virt-api` pods on your deployment:

--- a/alerts/openshift-virtualization-operator/VirtApiRESTErrorsBurst.md
+++ b/alerts/openshift-virtualization-operator/VirtApiRESTErrorsBurst.md
@@ -37,7 +37,7 @@ affected.
 4. Obtain the details of the `virt-api` pods:
 
    ```bash
-   $ oc describe pod -n $NAMESPACE <virt-api>
+   $ oc describe pods -n $NAMESPACE -l kubevirt.io=virt-api
    ```
 
 5. Check if any problems occurred with the nodes. For example, they might be in

--- a/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md
+++ b/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md
@@ -18,7 +18,7 @@ affected.
 1. Set the `NAMESPACE` environment variable as follows:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Check the status of the `virt-api` pods:

--- a/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md
+++ b/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md
@@ -18,7 +18,7 @@ affected.
 1. Set the `NAMESPACE` environment variable as follows:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Check the status of the `virt-api` pods:
@@ -36,7 +36,7 @@ affected.
 4. Obtain the details of the `virt-api` pods:
 
    ```bash
-   $ oc describe -n $NAMESPACE <virt-api>
+   $ oc describe pod -n $NAMESPACE <virt-api>
    ```
 
 5. Check if any problems occurred with the nodes. For example, they might be in

--- a/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md
+++ b/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md
@@ -36,7 +36,7 @@ affected.
 4. Obtain the details of the `virt-api` pods:
 
    ```bash
-   $ oc describe pod -n $NAMESPACE <virt-api>
+   $ oc describe pods -n $NAMESPACE -l kubevirt.io=virt-api
    ```
 
 5. Check if any problems occurred with the nodes. For example, they might be in

--- a/alerts/openshift-virtualization-operator/VirtControllerDown.md
+++ b/alerts/openshift-virtualization-operator/VirtControllerDown.md
@@ -13,7 +13,7 @@ an existing VMI.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Check the status of the `virt-controller` deployment:

--- a/alerts/openshift-virtualization-operator/VirtControllerDown.md
+++ b/alerts/openshift-virtualization-operator/VirtControllerDown.md
@@ -13,7 +13,7 @@ an existing VMI.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Check the status of the `virt-controller` deployment:

--- a/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsBurst.md
+++ b/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsBurst.md
@@ -26,7 +26,7 @@ However, running workloads are not impacted.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. List the available `virt-controller` pods:

--- a/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsBurst.md
+++ b/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsBurst.md
@@ -26,7 +26,7 @@ However, running workloads are not impacted.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. List the available `virt-controller` pods:

--- a/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsHigh.md
+++ b/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsHigh.md
@@ -27,7 +27,7 @@ current status might be delayed.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. List the available `virt-controller` pods:

--- a/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsHigh.md
+++ b/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsHigh.md
@@ -27,7 +27,7 @@ current status might be delayed.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. List the available `virt-controller` pods:

--- a/alerts/openshift-virtualization-operator/VirtHandlerDaemonSetRolloutFailing.md
+++ b/alerts/openshift-virtualization-operator/VirtHandlerDaemonSetRolloutFailing.md
@@ -18,7 +18,7 @@ Identify worker nodes that do not have a running `virt-handler` pod:
 1. Export the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Check the status of the `virt-handler` pods to identify pods that have not

--- a/alerts/openshift-virtualization-operator/VirtHandlerDaemonSetRolloutFailing.md
+++ b/alerts/openshift-virtualization-operator/VirtHandlerDaemonSetRolloutFailing.md
@@ -18,7 +18,7 @@ Identify worker nodes that do not have a running `virt-handler` pod:
 1. Export the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Check the status of the `virt-handler` pods to identify pods that have not

--- a/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsBurst.md
+++ b/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsBurst.md
@@ -27,7 +27,7 @@ fail. However, running workloads on the affected node are not impacted.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Check the status of the `virt-handler` pod:

--- a/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsBurst.md
+++ b/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsBurst.md
@@ -27,7 +27,7 @@ fail. However, running workloads on the affected node are not impacted.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Check the status of the `virt-handler` pod:

--- a/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsHigh.md
+++ b/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsHigh.md
@@ -26,7 +26,7 @@ but reporting their current status might be delayed.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. List the available `virt-handler` pods to identify the failing `virt-handler`

--- a/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsHigh.md
+++ b/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsHigh.md
@@ -26,7 +26,7 @@ but reporting their current status might be delayed.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. List the available `virt-handler` pods to identify the failing `virt-handler`

--- a/alerts/openshift-virtualization-operator/VirtOperatorDown.md
+++ b/alerts/openshift-virtualization-operator/VirtOperatorDown.md
@@ -31,7 +31,7 @@ affect VM workloads.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Check the status of the `virt-operator` deployment:

--- a/alerts/openshift-virtualization-operator/VirtOperatorDown.md
+++ b/alerts/openshift-virtualization-operator/VirtOperatorDown.md
@@ -31,7 +31,7 @@ affect VM workloads.
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Check the status of the `virt-operator` deployment:

--- a/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsBurst.md
+++ b/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsBurst.md
@@ -30,7 +30,7 @@ However, customer workloads, such as virtual machines (VMs) and VM instances
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Check the status of the `virt-operator` pods:

--- a/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsBurst.md
+++ b/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsBurst.md
@@ -30,7 +30,7 @@ However, customer workloads, such as virtual machines (VMs) and VM instances
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Check the status of the `virt-operator` pods:

--- a/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsHigh.md
+++ b/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsHigh.md
@@ -28,7 +28,7 @@ However, customer workloads, such as virtual machines (VMs) and VM instances
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
+   $ export NAMESPACE="$(oc get kubevirt -A -o jsonpath='{.items[].metadata.namespace}')"
    ```
 
 2. Check the status of the `virt-operator` pods:

--- a/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsHigh.md
+++ b/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsHigh.md
@@ -28,7 +28,7 @@ However, customer workloads, such as virtual machines (VMs) and VM instances
 1. Set the `NAMESPACE` environment variable:
 
    ```bash
-   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+   $ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
    ```
 
 2. Check the status of the `virt-operator` pods:


### PR DESCRIPTION
### Fix Incorrect Commands in Diagnosis Section of Runbooks in Monitoring doc

This PR modifies several commands in the Diagnosis section of the runbooks under the Monitoring section. The current commands contain errors or deprecated syntax, leading to issues when troubleshooting. Below are the necessary modifications:

**Modifications:**

1. CDIStorageProfilesIncomplete
* Current: Identify the incomplete storage profile using: oc get storageprofile <storage_class>
* Issue: This command only shows the storage profile associated with the given storage class but does not provide details on incompleteness. To identify incomplete ones, use: oc get storageprofile -o json | jq '.items[] | select(.status.claimPropertySets == null or .status.claimPropertySets == []) | .metadata.name'

2. KubeVirtVMIExcessiveMigrations
* Current: 
    * oc get nodes -l node-role.kubernetes.io/worker= -o json | jq .items[].status.allocatable
    * oc get nodes -l node-role.kubernetes.io/worker= -o json | jq .items[].status.conditions
* Issue: The commands fail due to missing single quotes. The correct versions are: 
    * oc get nodes -l node-role.kubernetes.io/worker= -o json | jq '.items[].status.allocatable'
    * oc get nodes -l node-role.kubernetes.io/worker= -o json | jq '.items[].status.conditions'

3. Runbooks: LowReadyVirtControllersCount, LowReadyVirtOperatorsCount, VirtAPIDown, etc.
* Issue: The namespace is exported incorrectly, causing errors due to the presence of “\n” along namespace.
* Fix: 
* export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | tr -d '\n')"
											OR
*  export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace | xargs)"

4. LowVirtControllersCount
* Current: 
    * oc -n $NAMESPACE logs <virt-launcher>
    * oc -n $NAMESPACE describe pod/<virt-launcher>
* Issue: It should refer to virt-controller instead: 
    * oc -n $NAMESPACE logs <virt-controller>
    * oc -n $NAMESPACE describe pod/<virt-controller>

5. NetworkAddonsConfigNotReady
* Current: oc get networkaddonsconfig -o custom-columns="":.status.conditions[*].message
* Issue: The commands fail due to missing single quotes in custom column formatting. The correct versions is: oc get networkaddonsconfig -o custom-columns=':.status.conditions[*].message'

* Current: oc -n cluster-network-addons get daemonset <pod> -o yaml
* Issue: Incorrect resource type in daemonset retrieval. The correct versions is: oc -n cluster-network-addons get daemonset <demonset> -o yaml

* Current: oc -n cluster-network-addons describe <pod>
* Issue: Incomplete syntax in describe command. The correct command is: oc -n cluster-network-addons describe pod <pod>

6. NoLeadingVirtOperator
* Current: oc -n $NAMESPACE logs | grep lead
* Issue: The command is incomplete. It should specify virt-operator: oc -n $NAMESPACE logs <virt-operator> | grep lead

7. NoReadyVirtController
* Current: get pods -n $NAMESPACE | grep virt-controller
* Issue: Missing oc prefix. The correct command is: oc get pods -n $NAMESPACE | grep virt-controller

8. OrphanedVirtualMachineInstances
* Current: oc get daemonset virt-handler --all-namespaces
* Issue: The command fails due to resource retrieval restrictions. The corrected version is: oc get daemonsets --all-namespaces | grep virt-handler

* Current: oc get daemonset virt-handler --all-namespaces -o yaml | jq .status
* Issue: The command fails because the virt-handler DaemonSet may exist in multiple namespaces, and oc get daemonset <name> does not support --all-namespaces. The correct version is: oc get daemonsets --all-namespaces -o json | jq '.items[] | select(.metadata.name=="virt-handler") | .status'

* Current: oc get kubevirt kubevirt --all-namespaces -o yaml
* Issue: The command fails due to namespace retrieval issues. The correct version is: oc get kubevirt -n <namespace> <KubeVirt-name> -o yaml

9. VirtApiRESTErrorsBurst, VirtApiRESTErrorsHigh
* Current: oc describe -n $NAMESPACE <virt-api>
* Issue: Missing pod keyword. The corrected command is: oc describe pod -n $NAMESPACE <virt-api>


