### PR TITLE
OCPBUGS-51193: Add runbook for CoreDNSErrorsHigh

### DIFF
--- a/alerts/cluster-dns-operator/CoreDNSErrorsHigh.md
+++ b/alerts/cluster-dns-operator/CoreDNSErrorsHigh.md
@@ -48,6 +48,6 @@ spec:
       ...output omitted...
 ```
 
-If there is a connectivity issue between the coredns pods and the upstream nameserver, review the undercloud connectivity.
+If there is a connectivity issue between the coredns pods and the upstream nameservers, review the undercloud connectivity.
 
 If the upstream nameservers is not healthy to respond to the queries by the coredns pods, apply a silence to the alert, until these servers are troubleshooted.

--- a/alerts/cluster-dns-operator/CoreDNSErrorsHigh.md
+++ b/alerts/cluster-dns-operator/CoreDNSErrorsHigh.md
@@ -1,0 +1,53 @@
+# CoreDNSErrorsHigh
+
+## Meaning
+
+CoreDNS is returning SERVFAIL more than 1% of total requests.
+
+## Impact
+
+Warning: Some requests are not resolved.
+
+## Diagnosis
+
+1. Check dns's operator:
+
+    ```shell
+    $ oc get co dns
+    ```
+
+2. Check dns's daemonsets if they are running on all nodes:
+
+    ```shell
+    $ oc get ds -n openshift-dns
+    ```
+
+3. Check dns' pods if they can reach upstream nameservers:
+
+    ```shell
+    $ oc exec -c dns dns-default-xxxxx -it -n openshift-dns -- dig www.example.com @$IP_OF_UPSTREAM_NAMESERVER
+    ```
+
+4. Check dns' upstream nameservers if they are returning SERVFAIL:
+
+    ```shell
+    $ oc logs -c dns -l dns.operator.openshift.io/daemonset-dns=default -n openshift-dns 
+    ```
+
+## Mitigation
+
+If there is a connectivity issue between the coredns pods and the workload, review the [Controlling DNS pod placement](https://docs.openshift.com/container-platform/4.17/networking/networking_operators/dns-operator.html#nw-controlling-dns-pod-placement_dns-operator):
+
+```shell
+$ oc edit dns.operator/default
+```
+
+```yaml
+spec:
+  nodePlacement:
+      ...output omitted...
+```
+
+If there is a connectivity issue between the coredns pods and the upstream nameserver, review the undercloud connectivity.
+
+If the upstream nameservers is not healthy to respond to the queries by the coredns pods, apply a silence to the alert, until these servers are troubleshooted.

--- a/alerts/cluster-dns-operator/CoreDNSErrorsHigh.md
+++ b/alerts/cluster-dns-operator/CoreDNSErrorsHigh.md
@@ -25,13 +25,13 @@ Warning: Some requests are not resolved.
 3. Check dns' pods if they can reach upstream nameservers:
 
     ```shell
-    $ oc exec -c dns dns-default-xxxxx -it -n openshift-dns -- dig www.example.com @$IP_OF_UPSTREAM_NAMESERVER
+    $ oc exec -c dns dns-default-xxxxx -it -n openshift-dns -- dig @$IP_OF_UPSTREAM_NAMESERVER -q $DOMAIN_NAME
     ```
 
 4. Check dns' upstream nameservers if they are returning SERVFAIL:
 
     ```shell
-    $ oc logs -c dns -l dns.operator.openshift.io/daemonset-dns=default -n openshift-dns 
+    $ oc logs -c dns -l dns.operator.openshift.io/daemonset-dns=default --max-log-requests $NUMBER_OF_COREDNS_PODS -n openshift-dns --timestamps --follow
     ```
 
 ## Mitigation

--- a/alerts/cluster-dns-operator/OWNERS
+++ b/alerts/cluster-dns-operator/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+- khalid-lemghari
+- Miciah
+- melvinjoseph86
+- candita
+reviewers:
+- khalid-lemghari
+- Miciah
+- melvinjoseph86
+- candita

--- a/alerts/cluster-dns-operator/OWNERS
+++ b/alerts/cluster-dns-operator/OWNERS
@@ -1,10 +1,8 @@
 approvers:
-- khalid-lemghari
 - Miciah
 - melvinjoseph86
 - candita
 reviewers:
-- khalid-lemghari
 - Miciah
 - melvinjoseph86
 - candita


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/OCPBUGS-51193

Problem: currently there is no clear direction on how to troubleshoot the alert. This alert comes from the Prometheus repo, so improving the description there with OpenShift-specific details doesn't seem to be the best approach.

Solution: Create a runbook to be linked in the OpenShift alert

