### PR TITLE
ci: disable MD059 to address markdown lint error

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -49,3 +49,6 @@ config:
   # Allow duplicate headings with different parents.
   no-duplicate-heading:
     siblings_only: true
+
+  # Disabling MD059/descriptive-link-text.
+  MD059: false


### PR DESCRIPTION
`markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)` introduces `Add MD059/descriptive-link-text` which results in lint failures in older runbooks. Disabling it to let CI pass. 
Future work: Enable this and update the older runbooks accordingly. 