### PR TITLE
Add runbooks for etcdGRPCReadRequestsSlow and etcdGRPCWriteRequestsSlow

### DIFF
--- a/alerts/cluster-etcd-operator/etcdGRPCReadRequestsSlow.md
+++ b/alerts/cluster-etcd-operator/etcdGRPCReadRequestsSlow.md
@@ -1,0 +1,44 @@
+# etcdGRPCReadRequestsSlow
+
+## Alert Description
+
+| Impacted User   | Impact |
+|:----------------|:-------|
+| Customer Impact | High   |
+| SREP Impact     | High   |
+
+**Severity:** Critical
+
+**Alert Expression:**
+```promql
+histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_method="Range", grpc_type="unary"}[10m])) without(grpc_type)) > 3
+```
+
+**Trigger Condition:** The 99th percentile of etcd gRPC Range (read) requests exceeds 3 seconds for 10 consecutive minutes.
+
+**What it means:** etcd is taking too long to serve read requests, which are critical for cluster operations. Range requests are the primary read operation in etcd's gRPC API, used by:
+- `kubectl get` commands (listing pods, nodes, deployments, etc.)
+- Kubernetes API server listing resources
+- Watch operation initialization
+- Any query for key-value data from etcd
+
+**Common Root Causes:**
+1. **Disk performance degradation** (~70% of cases) - Slow fsync operations
+2. **CPU/Memory exhaustion** (~15% of cases) - Resource contention on control plane
+3. **Network latency** (~10% of cases) - High peer round-trip time
+4. **Database size/quota issues** (~5% of cases) - Large database or approaching quota
+
+## Troubleshooting
+
+### Check for Correlated Critical Alerts
+
+This is a new alert introduced in OCP 4.22. It's signal closely matches with some existing alerts. Look for these commonly co-firing alerts to mitigate the issue using known resolution steps:
+
+1. **etcdHighFsyncDurations (CRITICAL)** - Most likely cause (95% correlation) - disk performance. Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdHighFsyncDurations.md).
+2. **etcdNoLeader (CRITICAL)** - May have fired 9+ minutes earlier (check history). Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdNoLeader.md).
+3. **etcdInsufficientMembers (CRITICAL)** - Quorum loss scenario. Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdInsufficientMembers.md).
+4. **etcdHighNumberOfFailedGRPCRequests (CRITICAL)** - Requests timing out. Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdHighNumberOfFailedGRPCRequests.md).
+
+### Refer to the `etcd` team
+
+If you are unsure about further steps to take, you can refer to common [etcd checks](https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/etcd.md#etcd-checks) to collect information on current situation of the `etcd` and refer it to the `etcd` team in #forum-ocp-etcd.

--- a/alerts/cluster-etcd-operator/etcdGRPCReadRequestsSlow.md
+++ b/alerts/cluster-etcd-operator/etcdGRPCReadRequestsSlow.md
@@ -14,9 +14,12 @@
 histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_method="Range", grpc_type="unary"}[10m])) without(grpc_type)) > 3
 ```
 
-**Trigger Condition:** The 99th percentile of etcd gRPC Range (read) requests exceeds 3 seconds for 10 consecutive minutes.
+**Trigger Condition:**
+The 99th percentile of etcd gRPC Range requests exceeds 3 seconds for 10 minutes.
 
-**What it means:** etcd is taking too long to serve read requests, which are critical for cluster operations. Range requests are the primary read operation in etcd's gRPC API, used by:
+**What it means:**
+etcd is taking too long to serve critical read requests.
+Range requests are the primary read operation in etcd's gRPC API, used by:
 - `kubectl get` commands (listing pods, nodes, deployments, etc.)
 - Kubernetes API server listing resources
 - Watch operation initialization
@@ -26,19 +29,29 @@ histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd"
 1. **Disk performance degradation** (~70% of cases) - Slow fsync operations
 2. **CPU/Memory exhaustion** (~15% of cases) - Resource contention on control plane
 3. **Network latency** (~10% of cases) - High peer round-trip time
-4. **Database size/quota issues** (~5% of cases) - Large database or approaching quota
+4. **Database size/quota issues** (~5% of cases) - Large database or quota limit
 
 ## Troubleshooting
 
 ### Check for Correlated Critical Alerts
 
-This is a new alert introduced in OCP 4.22. It's signal closely matches with some existing alerts. Look for these commonly co-firing alerts to mitigate the issue using known resolution steps:
+This alert's signal closely matches with some existing alerts.
+Look for these commonly co-firing alerts for mitigation steps:
 
-1. **etcdHighFsyncDurations (CRITICAL)** - Most likely cause (95% correlation) - disk performance. Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdHighFsyncDurations.md).
-2. **etcdNoLeader (CRITICAL)** - May have fired 9+ minutes earlier (check history). Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdNoLeader.md).
-3. **etcdInsufficientMembers (CRITICAL)** - Quorum loss scenario. Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdInsufficientMembers.md).
-4. **etcdHighNumberOfFailedGRPCRequests (CRITICAL)** - Requests timing out. Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdHighNumberOfFailedGRPCRequests.md).
+1. **etcdHighFsyncDurations (CRITICAL)** - Most likely cause - disk performance.
+Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdHighFsyncDurations.md).
+
+2. **etcdNoLeader (CRITICAL)** - May have fired 9+ minutes earlier.
+Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdNoLeader.md).
+
+3. **etcdInsufficientMembers (CRITICAL)** - Quorum loss scenario.
+Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdInsufficientMembers.md).
+
+4. **etcdHighNumberOfFailedGRPCRequests (CRITICAL)** - Requests timing out.
+Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdHighNumberOfFailedGRPCRequests.md).
 
 ### Refer to the `etcd` team
 
-If you are unsure about further steps to take, you can refer to common [etcd checks](https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/etcd.md#etcd-checks) to collect information on current situation of the `etcd` and refer it to the `etcd` team in #forum-ocp-etcd.
+If you are unsure about further steps to take, you can refer to common [etcd checks](https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/etcd.md#etcd-checks).
+Collect information on current situation of the `etcd`.
+You can also refer it to the `etcd` team in #forum-ocp-etcd.

--- a/alerts/cluster-etcd-operator/etcdGRPCWriteRequestsSlow.md
+++ b/alerts/cluster-etcd-operator/etcdGRPCWriteRequestsSlow.md
@@ -14,9 +14,13 @@
 histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_method="Txn", grpc_type="unary"}[10m])) without(grpc_type)) > 5
 ```
 
-**Trigger Condition:** The 99th percentile of etcd gRPC Txn (transaction/write) requests exceeds 5 seconds for 10 consecutive minutes.
+**Trigger Condition:**
+The 99th percentile of etcd gRPC Txn (write) requests exceeds 5 seconds for 10 minutes.
 
-**What it means:** etcd is taking too long to commit write requests, which are critical for maintaining cluster state. Transaction (Txn) requests are the primary write operation in etcd's gRPC API, used by:
+**What it means:**
+etcd is taking too long to commit critical write requests.
+Transaction requests are the primary write operation in etcd's gRPC API, used by:
+
 - `kubectl apply/create/delete/patch` commands
 - Kubernetes API server writing any resource changes
 - Pod scheduling and lifecycle operations
@@ -28,12 +32,19 @@ histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd"
 
 ### Check for Correlated Critical Alerts
 
-This is a new alert introduced in OCP 4.22. It's signal closely matches with some existing alerts. Look for these commonly co-firing alerts to mitigate the issue using known resolution steps:
+This alert's signal closely matches with some existing alerts.
+Look for these commonly co-firing alerts for mitigation steps:
 
-1. **etcdHighFsyncDurations (CRITICAL)** - Most likely cause (95% correlation) - disk write performance. Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdHighFsyncDurations.md).
-3. **etcdHighNumberOfFailedGRPCRequests (CRITICAL)** - Write requests timing out/failing (75% correlation). Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdHighNumberOfFailedGRPCRequests.md).
-4. **etcdGRPCReadRequestsSlow (CRITICAL)** - Same root cause affects reads too (65% correlation). Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdGRPCReadRequestsSlow.md).
+1. **etcdHighFsyncDurations (CRITICAL)** - Most likely cause- disk write performance.
+Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdHighFsyncDurations.md).
+
+3. **etcdHighNumberOfFailedGRPCRequests (CRITICAL)** - Write requests timing out/failing.
+Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdHighNumberOfFailedGRPCRequests.md).
+
+4. **etcdGRPCReadRequestsSlow (CRITICAL)** - Same root cause affects reads too.
+Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdGRPCReadRequestsSlow.md).
 
 ### Refer to the `etcd` team
 
-If you are unsure about further steps to take, you can refer to common [etcd checks](https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/etcd.md#etcd-checks) to collect information on current situation of the `etcd` and refer it to the `etcd` team in #forum-ocp-etcd.
+Collect information on current situation of the `etcd`.
+You can also refer it to the `etcd` team in #forum-ocp-etcd.

--- a/alerts/cluster-etcd-operator/etcdGRPCWriteRequestsSlow.md
+++ b/alerts/cluster-etcd-operator/etcdGRPCWriteRequestsSlow.md
@@ -1,0 +1,39 @@
+# etcdGRPCWriteRequestsSlow
+
+## Alert Description
+
+| Impacted User   | Impact |
+|:----------------|:-------|
+| Customer Impact | High   |
+| SREP Impact     | High   |
+
+**Severity:** Critical
+
+**Alert Expression:**
+```promql
+histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_method="Txn", grpc_type="unary"}[10m])) without(grpc_type)) > 5
+```
+
+**Trigger Condition:** The 99th percentile of etcd gRPC Txn (transaction/write) requests exceeds 5 seconds for 10 consecutive minutes.
+
+**What it means:** etcd is taking too long to commit write requests, which are critical for maintaining cluster state. Transaction (Txn) requests are the primary write operation in etcd's gRPC API, used by:
+- `kubectl apply/create/delete/patch` commands
+- Kubernetes API server writing any resource changes
+- Pod scheduling and lifecycle operations
+- Resource updates by controllers and operators
+- Any create/update/delete operation in the cluster
+- Cluster state modifications requiring Raft consensus
+
+## Troubleshooting
+
+### Check for Correlated Critical Alerts
+
+This is a new alert introduced in OCP 4.22. It's signal closely matches with some existing alerts. Look for these commonly co-firing alerts to mitigate the issue using known resolution steps:
+
+1. **etcdHighFsyncDurations (CRITICAL)** - Most likely cause (95% correlation) - disk write performance. Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdHighFsyncDurations.md).
+3. **etcdHighNumberOfFailedGRPCRequests (CRITICAL)** - Write requests timing out/failing (75% correlation). Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdHighNumberOfFailedGRPCRequests.md).
+4. **etcdGRPCReadRequestsSlow (CRITICAL)** - Same root cause affects reads too (65% correlation). Refer to the SOP [here](https://github.com/openshift/ops-sop/blob/master/v4/alerts/etcdGRPCReadRequestsSlow.md).
+
+### Refer to the `etcd` team
+
+If you are unsure about further steps to take, you can refer to common [etcd checks](https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/etcd.md#etcd-checks) to collect information on current situation of the `etcd` and refer it to the `etcd` team in #forum-ocp-etcd.


### PR DESCRIPTION
These 2 alerts are new additions for 4.22
- etcdGRPCReadRequestsSlow
- etcdGRPCWriteRequestsSlow

These runbooks provide us a starting point to
- Collect more information about etcd
- Determine common factors between these and other alerts
- Look into common factors that cause such alerts
