### PR TITLE
OCPEDGE-2710: add TNF alert runbooks

### DIFF
--- a/alerts/cluster-etcd-operator/TNFClusterInMaintenance.md
+++ b/alerts/cluster-etcd-operator/TNFClusterInMaintenance.md
@@ -1,0 +1,70 @@
+# TNFClusterInMaintenance
+
+## Meaning
+
+This alert fires when the entire Two Nodes with Fencing (TNF) Pacemaker
+cluster is placed in maintenance mode. The `tnf_cluster_in_service` metric
+reports `0` when the cluster-wide `maintenance-mode` property is set to `true`.
+
+This is a `warning` severity alert that fires after the condition persists for
+2 minutes.
+
+## Impact
+
+While in maintenance mode, Pacemaker stops monitoring and managing all
+resources on all nodes. This means:
+
+- No automatic failover if a node fails.
+- No fencing of unresponsive nodes.
+- No resource recovery (etcd, Kubelet) after failures.
+- The cluster is effectively unprotected against split-brain scenarios.
+
+Maintenance mode is typically enabled intentionally for administrative tasks.
+This alert serves as a reminder that protection is disabled.
+
+Operators may also see a console notification banner indicating the cluster is
+in maintenance mode.
+
+## Diagnosis
+
+Check whether maintenance mode is enabled:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs property show maintenance-mode
+```
+
+Check overall cluster status to see the effect on resources:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs status
+```
+
+Verify the metric value:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep tnf_cluster_in_service
+```
+
+## Mitigation
+
+If maintenance work is complete, disable maintenance mode:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs property set maintenance-mode=false
+```
+
+After disabling maintenance mode, verify that Pacemaker resumes resource
+monitoring:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs status
+```
+
+If maintenance mode was enabled unintentionally, disable it immediately.
+The cluster is unprotected while in maintenance mode.
+
+For operational guidance, see the [Two Nodes with Fencing
+documentation][docs].
+
+[docs]: https://docs.openshift.com/container-platform/latest/edge_computing/deploy-two-node-with-fencing.html

--- a/alerts/cluster-etcd-operator/TNFNodeCountMismatch.md
+++ b/alerts/cluster-etcd-operator/TNFNodeCountMismatch.md
@@ -1,0 +1,77 @@
+# TNFNodeCountMismatch
+
+## Meaning
+
+This alert fires when the Two Nodes with Fencing (TNF) cluster does not have
+the expected number of nodes. In a TNF topology, exactly two control-plane
+nodes are required. The `tnf_cluster_node_count_as_expected` metric reports `0`
+when Corosync membership diverges from the expected count.
+
+This is a `critical` severity alert that fires after the condition persists for
+5 minutes.
+
+> **Note:** This alert is classified as structurally unreachable in normal TNF
+> operation. Corosync membership is fixed at two nodes in `corosync.conf`, and
+> any deviation during node replacement is transient (seconds) and coincides
+> with API unavailability, preventing the alert from being evaluated. This
+> alert is included for edge-case completeness.
+
+## Impact
+
+If the cluster has fewer nodes than expected, etcd cannot maintain quorum and
+the Kubernetes API becomes unavailable for write operations. Pacemaker will
+attempt to fence the missing node and stop resources to protect data
+consistency.
+
+If an unexpected node has been added, cluster behavior is undefined as the TNF
+topology supports exactly two nodes.
+
+## Diagnosis
+
+Check overall Pacemaker cluster health from one of the nodes:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs status
+```
+
+Verify the current Corosync membership:
+
+```console
+$ oc debug node/<node-name> -- chroot /host corosync-cmapctl | grep members
+```
+
+Check the expected node configuration:
+
+```console
+$ oc debug node/<node-name> -- chroot /host grep -A5 'nodelist' /etc/corosync/corosync.conf
+```
+
+Verify the metric value from the etcd-operator:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep tnf_cluster_node_count_as_expected
+```
+
+Check the OpenShift node status:
+
+```console
+$ oc get nodes -l node-role.kubernetes.io/master=
+```
+
+## Mitigation
+
+Investigate why the node count has changed:
+
+- If a node was removed or is being replaced, verify the replacement procedure
+  was completed and the new node has joined the Pacemaker cluster.
+- If a node failed and was fenced, wait for it to recover and rejoin the
+  cluster. After recovery, verify that Corosync shows two members.
+
+In normal TNF operation, this alert is not expected to fire. If it persists,
+escalate to Red Hat support for guidance on the node replacement procedure.
+
+For operational guidance on degraded TNF clusters, see the [Two Nodes with
+Fencing documentation][docs].
+
+[docs]: https://docs.openshift.com/container-platform/latest/edge_computing/deploy-two-node-with-fencing.html

--- a/alerts/cluster-etcd-operator/TNFNodeFencingDegraded.md
+++ b/alerts/cluster-etcd-operator/TNFNodeFencingDegraded.md
@@ -2,11 +2,11 @@
 
 ## Meaning
 
-This alert fires when fencing for a node in the Two Nodes with Fencing (TNF)
-cluster is available but degraded. The `tnf_node_fencing_healthy` metric
-reports `0` while `tnf_node_fencing_available` is still `1`, indicating that
-one of multiple fence devices has failed while at least one remains
-operational.
+This alert fires when one or more fence devices for a node in the Two Nodes
+with Fencing (TNF) cluster have failed, but at least one device remains
+operational — a state referred to as *fencing degraded*. The
+`tnf_node_fencing_healthy` metric reports `0` while
+`tnf_node_fencing_available` is still `1`.
 
 This is a `warning` severity alert that fires after the condition persists for
 10 minutes.

--- a/alerts/cluster-etcd-operator/TNFNodeFencingDegraded.md
+++ b/alerts/cluster-etcd-operator/TNFNodeFencingDegraded.md
@@ -1,0 +1,74 @@
+# TNFNodeFencingDegraded
+
+## Meaning
+
+This alert fires when fencing for a node in the Two Nodes with Fencing (TNF)
+cluster is available but degraded. The `tnf_node_fencing_healthy` metric
+reports `0` while `tnf_node_fencing_available` is still `1`, indicating that
+one of multiple fence devices has failed while at least one remains
+operational.
+
+This is a `warning` severity alert that fires after the condition persists for
+10 minutes.
+
+> **Note:** This alert requires a multi-agent fencing setup where a node has
+> more than one fence device configured. In current TNF deployments, each node
+> typically has a single Redfish BMC agent, making this alert uncommon.
+
+## Impact
+
+Fencing redundancy is reduced. The cluster can still fence the node using the
+remaining healthy device(s), but if those also fail, fencing becomes
+unavailable entirely (triggering `TNFNodeFencingUnavailable`).
+
+## Diagnosis
+
+Check the status of all STONITH devices:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs stonith status
+```
+
+Identify which device has failed:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs stonith config
+```
+
+Check the fail count for each fence device:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs stonith failcount show <device-name>
+```
+
+Verify the metric values:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep -E 'tnf_node_fencing_(healthy|available)'
+```
+
+## Mitigation
+
+Reset the failed fence device:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs stonith cleanup <device-name>
+```
+
+If the device continues to fail, check its configuration:
+
+- Verify BMC connectivity for the affected device.
+- Verify credentials are correct.
+- Check the device-specific configuration parameters.
+
+After remediation, confirm all fence devices are healthy:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs stonith status
+```
+
+For operational guidance, see the [Two Nodes with Fencing
+documentation][docs].
+
+[docs]: https://docs.openshift.com/container-platform/latest/edge_computing/deploy-two-node-with-fencing.html

--- a/alerts/cluster-etcd-operator/TNFNodeFencingUnavailable.md
+++ b/alerts/cluster-etcd-operator/TNFNodeFencingUnavailable.md
@@ -1,0 +1,112 @@
+# TNFNodeFencingUnavailable
+
+## Meaning
+
+This alert fires when fencing (STONITH) is not available for a node in the Two
+Nodes with Fencing (TNF) cluster. The `tnf_node_fencing_available` metric
+reports `0` when all fence devices for the node are unhealthy, meaning the
+cluster cannot safely fence the node in case of failure.
+
+Common causes include an unreachable BMC (Redfish endpoint), invalid BMC
+credentials, or all fence devices being administratively disabled.
+
+This is a `critical` severity alert that fires after the condition persists for
+5 minutes.
+
+## Impact
+
+Without fencing, the cluster cannot protect against split-brain scenarios. If
+a node failure occurs while fencing is unavailable, Pacemaker cannot guarantee
+data consistency and will refuse to start resources on the surviving node. The
+cluster is effectively unprotected.
+
+Operators may also see a console notification banner indicating that fencing is
+unavailable.
+
+## Diagnosis
+
+Check the status of STONITH devices:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs stonith status
+```
+
+Check the detailed STONITH configuration:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs stonith config
+```
+
+Check the fail count for fence devices:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs stonith show <device-name> --full
+```
+
+Verify the metric value:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep tnf_node_fencing_available
+```
+
+### BMC connectivity
+
+Test connectivity to the BMC (Redfish) endpoint from the node:
+
+```console
+$ oc debug node/<node-name> -- chroot /host curl -sk https://<bmc-ip>/redfish/v1/Systems
+```
+
+### Fencing retry exhaustion
+
+After `stonith-max-attempts` (default: 10) failed fencing attempts, Pacemaker
+**stops retrying permanently**. The fencing operation transitions to
+`pcmk__graph_wait` and no further attempts are made, even if the BMC becomes
+reachable again. Pacemaker does **not** automatically re-probe.
+
+Check whether the fail count has reached the maximum:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs stonith failcount show <device-name>
+```
+
+## Mitigation
+
+### Fix BMC connectivity
+
+1. Verify the BMC network is reachable from both nodes.
+2. Verify BMC credentials are correct in the STONITH resource configuration.
+3. If the BMC was temporarily unreachable, verify it is back online.
+
+### Re-enable disabled fence devices
+
+If the fence device was administratively disabled:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs stonith enable <device-name>
+```
+
+### Reset after fencing retry exhaustion
+
+After fixing the underlying issue (BMC connectivity, credentials), you
+**must** manually reset the fail count. Recovery is **not** automatic:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs stonith cleanup <device-name>
+```
+
+This resets the fail count and triggers Pacemaker to re-probe the fence device.
+
+### Verify recovery
+
+After remediation, confirm that fencing is available:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs stonith status
+```
+
+For operational guidance, see the [Two Nodes with Fencing
+documentation][docs].
+
+[docs]: https://docs.openshift.com/container-platform/latest/edge_computing/deploy-two-node-with-fencing.html

--- a/alerts/cluster-etcd-operator/TNFNodeInMaintenance.md
+++ b/alerts/cluster-etcd-operator/TNFNodeInMaintenance.md
@@ -1,0 +1,71 @@
+# TNFNodeInMaintenance
+
+## Meaning
+
+This alert fires when a specific node in the Two Nodes with Fencing (TNF)
+cluster is placed in maintenance mode. The `tnf_node_in_service` metric
+reports `0` when a node-level maintenance flag is set, meaning Pacemaker stops
+monitoring resources on that node while continuing to monitor the other node.
+
+This is different from cluster-wide maintenance mode
+(`TNFClusterInMaintenance`), which affects all nodes.
+
+This is a `warning` severity alert that fires after the condition persists for
+2 minutes.
+
+## Impact
+
+While a node is in maintenance mode:
+
+- Pacemaker stops monitoring resources on that node.
+- Resources on the node continue to run but are not managed.
+- If a resource fails on the maintenance node, Pacemaker will not restart it
+  or take corrective action.
+- Fencing is still active for the node (unlike cluster-wide maintenance mode).
+
+Operators may also see a console notification banner indicating the node is in
+maintenance mode.
+
+## Diagnosis
+
+Check which nodes are in maintenance mode:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs status
+```
+
+Check node attributes for the maintenance flag:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs node attribute
+```
+
+Verify the metric value:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep tnf_node_in_service
+```
+
+## Mitigation
+
+If maintenance work on the node is complete, remove the maintenance flag:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs node unmaintenance <node-name>
+```
+
+After removing maintenance mode, verify that Pacemaker resumes resource
+monitoring on the node:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs status
+```
+
+If maintenance mode was enabled unintentionally, remove it immediately.
+Resources on the node are unmonitored while in maintenance mode.
+
+For operational guidance, see the [Two Nodes with Fencing
+documentation][docs].
+
+[docs]: https://docs.openshift.com/container-platform/latest/edge_computing/deploy-two-node-with-fencing.html

--- a/alerts/cluster-etcd-operator/TNFNodeOffline.md
+++ b/alerts/cluster-etcd-operator/TNFNodeOffline.md
@@ -1,0 +1,87 @@
+# TNFNodeOffline
+
+## Meaning
+
+This alert fires when a node in the Two Nodes with Fencing (TNF) cluster is
+offline. The `tnf_node_online` metric reports `0` when Corosync has lost
+communication with the node, indicating a node failure, reboot, or network
+partition.
+
+This is a `critical` severity alert that fires after the condition persists for
+2 minutes.
+
+## Impact
+
+In a two-node cluster, losing one node means etcd loses quorum (1 of 2
+members). The Kubernetes API becomes unavailable for write operations.
+Pacemaker will attempt to fence the offline node via STONITH to ensure data
+consistency before stopping resources on the surviving node.
+
+If fencing succeeds, the surviving node transitions to a known-good state with
+resources stopped. If fencing fails, the cluster remains frozen in an unclean
+state.
+
+## Diagnosis
+
+Check Pacemaker cluster status from the surviving node:
+
+```console
+$ oc debug node/<surviving-node> -- chroot /host pcs status
+```
+
+> **Note:** If the offline node was hosting the Prometheus pod, the
+> `oc port-forward` session may break. Re-establish it from the surviving
+> node if needed.
+
+Check detailed node states:
+
+```console
+$ oc debug node/<surviving-node> -- chroot /host crm_mon -1
+```
+
+Verify node status from the OpenShift perspective:
+
+```console
+$ oc get nodes -l node-role.kubernetes.io/master=
+```
+
+Check the metric value:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep tnf_node_online
+```
+
+Check for any related alerts that may help with diagnosis:
+
+```console
+$ curl -s 'localhost:9090/api/v1/query?query=ALERTS{alertname=~"TNF.*"}' | jq
+```
+
+### Hardware and network investigation
+
+- Verify the node's hardware status via the BMC (Redfish) console.
+- Check network connectivity between the two nodes.
+- Review system logs on the surviving node for Corosync communication errors.
+
+## Mitigation
+
+- If the node is rebooting (e.g., after an upgrade or maintenance), wait for
+  it to come back online. Pacemaker will automatically re-integrate the node
+  when Corosync communication is restored.
+- If the node has failed due to a hardware issue, address the hardware problem
+  and power the node back on.
+- If there is a network partition, restore network connectivity between the
+  nodes.
+
+After the node recovers, verify that both nodes are online and resources are
+running:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs status
+```
+
+For operational guidance on degraded TNF clusters, see the [Two Nodes with
+Fencing documentation][docs].
+
+[docs]: https://docs.openshift.com/container-platform/latest/edge_computing/deploy-two-node-with-fencing.html

--- a/alerts/cluster-etcd-operator/TNFNodeStandby.md
+++ b/alerts/cluster-etcd-operator/TNFNodeStandby.md
@@ -1,0 +1,69 @@
+# TNFNodeStandby
+
+## Meaning
+
+This alert fires when a node in the Two Nodes with Fencing (TNF) cluster is
+placed in standby mode. The `tnf_node_active` metric reports `0` when a node
+is in standby, meaning Pacemaker will move all resources off the node and
+prevent new resources from being started on it.
+
+This is a `warning` severity alert that fires after the condition persists for
+5 minutes.
+
+## Impact
+
+When a node is in standby:
+
+- All resources running on the node are stopped.
+- In a two-node cluster, this means resources can only run on the remaining
+  active node.
+- etcd loses one member, which in a two-node cluster means quorum is lost and
+  the Kubernetes API becomes unavailable for write operations.
+- The node remains a member of the Pacemaker cluster and fencing is still
+  active.
+
+Operators may also see a console notification banner indicating the node state.
+
+## Diagnosis
+
+Check which nodes are in standby:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs status
+```
+
+Check node attributes:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs node attribute
+```
+
+Verify the metric value:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep tnf_node_active
+```
+
+## Mitigation
+
+If the standby was intentional and the maintenance work is complete, remove
+the standby flag:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs node unstandby <node-name>
+```
+
+After removing standby, verify that resources restart on the node:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs status
+```
+
+If standby was enabled unintentionally, remove it immediately. The cluster is
+operating in a degraded state with only one active node.
+
+For operational guidance, see the [Two Nodes with Fencing
+documentation][docs].
+
+[docs]: https://docs.openshift.com/container-platform/latest/edge_computing/deploy-two-node-with-fencing.html

--- a/alerts/cluster-etcd-operator/TNFNodeUnclean.md
+++ b/alerts/cluster-etcd-operator/TNFNodeUnclean.md
@@ -1,0 +1,101 @@
+# TNFNodeUnclean
+
+## Meaning
+
+This alert fires when a node in the Two Nodes with Fencing (TNF) cluster is in
+an "unclean" state. The `tnf_node_clean` metric reports `0` when Corosync has
+lost contact with the node but fencing has not yet completed or has failed. The
+node's state cannot be confirmed as safe.
+
+This is a `critical` severity alert that fires after the condition persists for
+5 minutes.
+
+> **Note:** This alert is classified as an API blind spot in 2-node topology.
+> The unclean state always coincides with etcd quorum loss (1 of 2 members
+> available means no quorum), so the Kubernetes API is unavailable and the
+> PacemakerCluster CR cannot be updated to record this state. This alert is
+> included for edge-case completeness but is expected to have zero practical
+> firings under normal conditions.
+
+## Impact
+
+While a node is unclean, Pacemaker will not start resources on the surviving
+node to prevent a split-brain scenario. The cluster is effectively frozen:
+
+- etcd is not running (quorum lost).
+- The Kubernetes API is unavailable.
+- No workloads can be scheduled.
+
+The cluster remains in this state until fencing succeeds (confirming the failed
+node is powered off) or an administrator intervenes.
+
+### Typical timeline
+
+1. Node goes offline, Corosync detects loss of communication.
+2. Node transitions to `unclean` state.
+3. etcd quorum is lost, API becomes unavailable.
+4. Pacemaker initiates fencing via STONITH.
+5. If fencing succeeds: node transitions to `offline` (clean), resources stop
+   gracefully.
+6. If fencing fails: cluster remains frozen indefinitely until manual
+   intervention.
+
+## Diagnosis
+
+Check Pacemaker status from the surviving node:
+
+```console
+$ oc debug node/<surviving-node> -- chroot /host crm_mon -1
+```
+
+Check for fencing activity:
+
+```console
+$ oc debug node/<surviving-node> -- chroot /host pcs stonith status
+```
+
+Check STONITH history for recent fencing attempts:
+
+```console
+$ oc debug node/<surviving-node> -- chroot /host pcs stonith history
+```
+
+If the API is available, check the metric value:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep tnf_node_clean
+```
+
+## Mitigation
+
+### If fencing is in progress
+
+Wait for the fencing operation to complete. Once the failed node is
+successfully fenced (powered off via BMC), Pacemaker will mark it as clean and
+proceed with resource management.
+
+### If fencing has failed
+
+Manually fence the unclean node:
+
+```console
+$ oc debug node/<surviving-node> -- chroot /host pcs stonith fence <unclean-node>
+```
+
+If manual fencing also fails, verify BMC connectivity and credentials, then
+retry. See the `TNFNodeFencingUnavailable` runbook for BMC troubleshooting
+steps.
+
+### After recovery
+
+Once fencing succeeds, verify the cluster returns to a healthy state:
+
+```console
+$ oc debug node/<surviving-node> -- chroot /host pcs status
+```
+
+For operational guidance on degraded TNF clusters, see the [Two Nodes with
+Fencing documentation][docs].
+
+[docs]: https://docs.openshift.com/container-platform/latest/edge_computing/deploy-two-node-with-fencing.html

--- a/alerts/cluster-etcd-operator/TNFResourceDisabled.md
+++ b/alerts/cluster-etcd-operator/TNFResourceDisabled.md
@@ -1,0 +1,91 @@
+# TNFResourceDisabled
+
+## Meaning
+
+This alert fires when a Pacemaker-managed resource in the Two Nodes with
+Fencing (TNF) cluster has been administratively disabled. The
+`tnf_resource_enabled` metric reports `0` when a resource is disabled,
+meaning Pacemaker has stopped the resource and will not start it.
+
+Resources managed by Pacemaker in a TNF cluster include `Etcd` and `Kubelet`.
+The alert labels identify the specific `resource` and `node`.
+
+This is a `warning` severity alert that fires after the condition persists for
+5 minutes.
+
+> **Note:** Disabling a resource also stops it, so the `TNFResourceStopped`
+> alert may fire at the same time for the same resource.
+
+## Impact
+
+A disabled resource is intentionally stopped. The impact depends on which
+resource is disabled:
+
+- **Etcd**: The node loses its etcd member. In a two-node cluster, this means
+  quorum is lost and the Kubernetes API becomes unavailable.
+- **Kubelet**: The node cannot run workloads.
+
+> **Warning:** In a two-node TNF cluster, disabling any Pacemaker clone
+> resource (`etcd-clone` or `kubelet-clone`) is destructive. Resource ordering
+> constraints cause cascading stops — disabling `kubelet-clone` also stops
+> `etcd-clone`. The Kubernetes API becomes unavailable, and recovery requires
+> direct node access (SSH or BMC console) to re-enable the resource.
+
+## Diagnosis
+
+Check the resource status to identify disabled resources:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs resource status
+```
+
+Check overall cluster status:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs status
+```
+
+Verify the metric value:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep tnf_resource_enabled
+```
+
+### Post-recovery investigation
+
+Check the disruption counter to see if the resource experienced transitions:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep tnf_resource_disruption_total
+```
+
+Query the disruption rate in Prometheus:
+
+```console
+$ curl -s 'localhost:9090/api/v1/query?query=rate(tnf_resource_disruption_total[10m])' | jq
+```
+
+## Mitigation
+
+If the resource was disabled intentionally and the work is complete, re-enable
+it:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs resource enable <resource-name>
+```
+
+After re-enabling, verify that the resource starts and is running:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs resource status
+```
+
+If the resource was disabled unintentionally, re-enable it immediately. The
+cluster is operating in a degraded state while the resource is disabled.
+
+For operational guidance, see the [Two Nodes with Fencing
+documentation][docs].
+
+[docs]: https://docs.openshift.com/container-platform/latest/edge_computing/deploy-two-node-with-fencing.html

--- a/alerts/cluster-etcd-operator/TNFResourceFailed.md
+++ b/alerts/cluster-etcd-operator/TNFResourceFailed.md
@@ -1,0 +1,103 @@
+# TNFResourceFailed
+
+## Meaning
+
+This alert fires when a Pacemaker-managed resource in the Two Nodes with
+Fencing (TNF) cluster has failed. The `tnf_resource_operational` metric
+reports `0` when a resource agent reported an error during a monitor, start,
+or stop operation.
+
+Resources managed by Pacemaker in a TNF cluster include `Etcd` and `Kubelet`.
+The alert labels identify the specific `resource` and `node`.
+
+This is a `critical` severity alert that fires after the condition persists for
+2 minutes.
+
+> **Note:** For the `Etcd` resource, this alert is an API blind spot in
+> 2-node topology. If the etcd process dies, quorum is lost (1 of 2 members),
+> and the Kubernetes API becomes unavailable, preventing the PacemakerCluster
+> CR from being updated. Only the `Kubelet` resource failure path fires in
+> practice through the normal observability pipeline.
+
+## Impact
+
+A failed resource indicates an operational error. Pacemaker may automatically
+attempt to restart the resource depending on the failure count and configured
+thresholds. If the failure persists beyond the retry limit, the resource
+remains stopped and manual intervention is required.
+
+Operators may also see a console notification banner indicating a resource
+failure.
+
+## Diagnosis
+
+Check the resource status and fail count:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs resource status
+```
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs resource failcount show <resource-name>
+```
+
+Check the resource agent logs for error details:
+
+```console
+$ oc debug node/<node-name> -- chroot /host journalctl -u pacemaker -n 100 --no-pager
+```
+
+Check overall cluster status:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs status
+```
+
+Verify the metric value:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep tnf_resource_operational
+```
+
+### Post-recovery investigation
+
+Check the disruption counter to see if the resource experienced transitions
+during API downtime:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep tnf_resource_disruption_total
+```
+
+Query the disruption rate in Prometheus:
+
+```console
+$ curl -s 'localhost:9090/api/v1/query?query=rate(tnf_resource_disruption_total[10m])' | jq
+```
+
+## Mitigation
+
+Reset the resource fail count and trigger Pacemaker to re-probe the resource:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs resource cleanup <resource-name>
+```
+
+If the resource continues to fail after cleanup:
+
+- Check the resource agent configuration for errors.
+- For `Etcd`: verify the etcd data directory, podman container state, and
+  network connectivity.
+- For `Kubelet`: verify the kubelet service status and configuration.
+
+After remediation, verify the resource is operational:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs resource status
+```
+
+For operational guidance, see the [Two Nodes with Fencing
+documentation][docs].
+
+[docs]: https://docs.openshift.com/container-platform/latest/edge_computing/deploy-two-node-with-fencing.html

--- a/alerts/cluster-etcd-operator/TNFResourceStopped.md
+++ b/alerts/cluster-etcd-operator/TNFResourceStopped.md
@@ -1,0 +1,89 @@
+# TNFResourceStopped
+
+## Meaning
+
+This alert fires when a Pacemaker-managed resource in the Two Nodes with
+Fencing (TNF) cluster has stopped and is not running on a node. The
+`tnf_resource_started` metric reports `0` for the affected resource and node.
+
+Resources managed by Pacemaker in a TNF cluster include `Etcd` and `Kubelet`.
+The alert labels identify the specific `resource` and `node`.
+
+This is a `critical` severity alert that fires after the condition persists for
+5 minutes.
+
+## Impact
+
+The impact depends on which resource has stopped:
+
+- **Etcd**: The node is no longer contributing an etcd member. In a two-node
+  cluster, this means quorum is lost and the Kubernetes API becomes
+  unavailable for write operations.
+- **Kubelet**: The node cannot run workloads. Pods on the node will not be
+  managed.
+
+The `TNFResourceDisabled` alert may also fire if the resource was
+administratively disabled. Resource ordering constraints mean that disabling
+one clone resource (e.g. `kubelet-clone`) may cascade and stop other
+resources (e.g. `etcd-clone`).
+
+## Diagnosis
+
+Check the status of all Pacemaker-managed resources:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs resource status
+```
+
+Check overall cluster status:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs status
+```
+
+Verify the metric value:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep tnf_resource_started
+```
+
+### Post-recovery investigation
+
+Check the disruption counter to see if the resource experienced
+`started -> stopped` transitions, including any that may have occurred during
+API downtime:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep tnf_resource_disruption_total
+```
+
+Query the disruption rate in Prometheus:
+
+```console
+$ curl -s 'localhost:9090/api/v1/query?query=rate(tnf_resource_disruption_total[10m])' | jq
+```
+
+## Mitigation
+
+If the resource was intentionally stopped or disabled, re-enable it:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs resource enable <resource-name>
+```
+
+If the resource stopped due to quorum loss after a node failure, investigate
+the root cause (see `TNFNodeOffline` runbook) and wait for the cluster to
+recover.
+
+After remediation, verify the resource is running:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs resource status
+```
+
+For operational guidance, see the [Two Nodes with Fencing
+documentation][docs].
+
+[docs]: https://docs.openshift.com/container-platform/latest/edge_computing/deploy-two-node-with-fencing.html

--- a/alerts/cluster-etcd-operator/TNFResourceUnmanaged.md
+++ b/alerts/cluster-etcd-operator/TNFResourceUnmanaged.md
@@ -1,0 +1,80 @@
+# TNFResourceUnmanaged
+
+## Meaning
+
+This alert fires when a Pacemaker-managed resource in the Two Nodes with
+Fencing (TNF) cluster has been placed in unmanaged mode. The
+`tnf_resource_managed` metric reports `0` when a resource is unmanaged,
+meaning Pacemaker stops monitoring the resource but does not stop it.
+
+Resources managed by Pacemaker in a TNF cluster include `Etcd` and `Kubelet`.
+The alert labels identify the specific `resource` and `node`.
+
+This is a `warning` severity alert that fires after the condition persists for
+5 minutes.
+
+## Impact
+
+While a resource is unmanaged:
+
+- The resource continues to run but is not monitored by Pacemaker.
+- If the resource fails, Pacemaker will not restart it or take any corrective
+  action.
+- Automatic failover is disabled for this resource.
+
+Unmanaging a resource is typically done intentionally for debugging or manual
+maintenance.
+
+## Diagnosis
+
+Check the resource status to identify unmanaged resources:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs resource status
+```
+
+Check overall cluster status:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs status
+```
+
+Verify the metric value:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep tnf_resource_managed
+```
+
+### Post-recovery investigation
+
+Check the disruption counter to see if the resource experienced transitions
+while unmanaged:
+
+```console
+$ oc exec -n openshift-etcd-operator deploy/etcd-operator -- \
+    curl -sk https://localhost:8443/metrics | grep tnf_resource_disruption_total
+```
+
+## Mitigation
+
+If the maintenance or debugging work is complete, return the resource to
+managed mode:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs resource manage <resource-name>
+```
+
+After re-managing the resource, verify that Pacemaker resumes monitoring:
+
+```console
+$ oc debug node/<node-name> -- chroot /host pcs resource status
+```
+
+If the resource was unmanaged unintentionally, re-manage it immediately. The
+resource is not protected while unmanaged.
+
+For operational guidance, see the [Two Nodes with Fencing
+documentation][docs].
+
+[docs]: https://docs.openshift.com/container-platform/latest/edge_computing/deploy-two-node-with-fencing.html


### PR DESCRIPTION
## Summary

- Add 12 operational runbooks for Two Nodes with Fencing (TNF) alerts in `alerts/cluster-etcd-operator/`
- Each runbook follows the existing CEO format: **Meaning > Impact > Diagnosis > Mitigation**
- Covers cluster-level (2), node-level (6), and resource-level (4) Pacemaker alerts

### Alerts covered

| Alert | Severity | Category |
|-------|----------|----------|
| TNFNodeCountMismatch | critical | cluster |
| TNFClusterInMaintenance | warning | cluster |
| TNFNodeOffline | critical | node |
| TNFNodeFencingUnavailable | critical | node |
| TNFNodeFencingDegraded | warning | node |
| TNFNodeUnclean | critical | node |
| TNFNodeInMaintenance | warning | node |
| TNFNodeStandby | warning | node |
| TNFResourceStopped | critical | resource |
| TNFResourceFailed | critical | resource |
| TNFResourceUnmanaged | warning | resource |
| TNFResourceDisabled | warning | resource |

## Context

These runbooks correspond to the TNF PrometheusRule alerts added in [cluster-etcd-operator#1650](https://github.com/openshift/cluster-etcd-operator/pull/1650). The `runbook_url` annotations in that PR already point to these file paths.

## Validation

All 12 runbooks validated on live TNF clusters (OCP 5.0 nightly, Pacemaker 3.0.1):
- Diagnosis and mitigation commands tested end-to-end
- API blind spot caveats documented for etcd-related alerts
- Resource disable cascade behavior documented

## JIRA

[OCPEDGE-2710](https://redhat.atlassian.net/browse/OCPEDGE-2710)